### PR TITLE
Add workflow to always create deployment PR

### DIFF
--- a/.github/workflows/main_to_prod.yml
+++ b/.github/workflows/main_to_prod.yml
@@ -1,0 +1,17 @@
+name: Main to Prod
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  main_to_prod:
+    name: Create pull request
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Open PR
+        run: gh pr create --base prod --title "Production deployment" --body ""
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        # @todo find exit codes when PR exists or no changes required.
+        continue-on-error: true


### PR DESCRIPTION
This should cause a PR to be opened whenever `main` is ahead of `prod` to let us deploy.

Fixes https://github.com/simplytestme/website/issues/41