### PR TITLE
Make project refresh more reliable

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -37,12 +37,12 @@ environments:
               tls-acme: "true"
     cronjobs:
       - name: drush cron
-        schedule: "*/20 * * * *"
+        schedule: "*/30 * * * *"
         command: drush cron
         service: cli
       - name: simplytest_projects_project_refresher
-        schedule: "*/5 * * * *"
-        command: drush queue:run simplytest_projects_project_refresher --items-limit 15
+        schedule: "* * * * *"
+        command: drush queue:run simplytest_projects_project_refresher --items-limit 50
         service: cli
   main:
     routes:
@@ -55,10 +55,10 @@ environments:
               tls-acme: "true"
     cronjobs:
       - name: drush cron
-        schedule: "*/20 * * * *"
+        schedule: "*/30 * * * *"
         command: drush cron
         service: cli
       - name: simplytest_projects_project_refresher
-        schedule: "*/5 * * * *"
-        command: drush queue:run simplytest_projects_project_refresher --items-limit 15
+        schedule: "* * * * *"
+        command: drush queue:run simplytest_projects_project_refresher --items-limit 50
         service: cli

--- a/web/modules/custom/simplytest_projects/simplytest_projects.module
+++ b/web/modules/custom/simplytest_projects/simplytest_projects.module
@@ -7,7 +7,7 @@ use Drupal\simplytest_projects\Entity\SimplytestProject;
  * Implements hook_ENTITY_TYPE_insert().
  */
 function simplytest_projects_simplytest_project_insert(SimplytestProject $project) {
-  $project_version_manager = \Drupal::getContainer()->get('simplytest_projects.project_version_manager');
+  $project_version_manager = \Drupal::getContainer()?->get('simplytest_projects.project_version_manager');
   assert($project_version_manager !== NULL);
   $project_version_manager->updateData($project->getShortname());
 }
@@ -27,7 +27,8 @@ function simplytest_projects_cron() {
   $query = $project_storage->getQuery()
     ->accessCheck(FALSE)
     ->condition('timestamp', strtotime('-4 hour'), '<')
-    ->range(0, 50);
+    ->sort('timestamp', 'ASC')
+    ->range(0, 100);
   $project_ids = $query->execute();
 
   $queue = \Drupal::queue('simplytest_projects_project_refresher');

--- a/web/modules/custom/simplytest_projects/simplytest_projects.services.yml
+++ b/web/modules/custom/simplytest_projects/simplytest_projects.services.yml
@@ -1,8 +1,8 @@
 services:
   logger.channel.simplytest_projects:
+    class: Drupal\Core\Logger\LoggerChannel
     parent: logger.channel_base
     arguments: ['simplytest_projects']
-    public: false
 
   simplytest_projects.fetcher:
     class: Drupal\simplytest_projects\ProjectFetcher

--- a/web/modules/custom/simplytest_projects/src/ProjectVersionManager.php
+++ b/web/modules/custom/simplytest_projects/src/ProjectVersionManager.php
@@ -33,20 +33,20 @@ final class ProjectVersionManager {
     $this->fetcher = $fetcher;
   }
 
-  public function updateData(string $project) {
+  public function updateData(string $project): void {
     $invalidate_caches = FALSE;
     foreach (['current', '7.x'] as $channel) {
       try {
         $release_xml = $this->fetcher->getProjectData($project, $channel);
       }
-      catch (ReleaseHistoryNotModifiedException $e) {
+      catch (ReleaseHistoryNotModifiedException) {
         // The release history has not been modified, so skip processing.
         continue;
       }
       try {
         $release_data = Processor::getData($release_xml);
       }
-      catch (NoReleaseHistoryFoundException $e) {
+      catch (NoReleaseHistoryFoundException) {
         continue;
       }
       $invalidate_caches = TRUE;


### PR DESCRIPTION
- Sort by timestamp so oldest projects are processed
- Bump cron to 30 minutes for native CronJob in Lagoon
- Run project refresh queue every minute
- Add logging to project refresh worker

Try to fix #222
