### PR TITLE
Queue 1250 projects at each cron

### DIFF
--- a/web/modules/custom/simplytest_projects/simplytest_projects.module
+++ b/web/modules/custom/simplytest_projects/simplytest_projects.module
@@ -28,7 +28,7 @@ function simplytest_projects_cron() {
     ->accessCheck(FALSE)
     ->condition('timestamp', strtotime('-4 hour'), '<')
     ->sort('timestamp', 'ASC')
-    ->range(0, 100);
+    ->range(0, 1250);
   $project_ids = $query->execute();
 
   $queue = \Drupal::queue('simplytest_projects_project_refresher');


### PR DESCRIPTION
The queue processes 50 each minute. Cron runs every 30 minutes. `30 * 50 = 1500`, queueing `1250` at a time leaves some margin.

part of #222 222