### PR TITLE
Set max-age to API responses for 5 minutes

### DIFF
--- a/web/modules/custom/simplytest_projects/simplytest_projects.services.yml
+++ b/web/modules/custom/simplytest_projects/simplytest_projects.services.yml
@@ -21,3 +21,8 @@ services:
   simplytest_projects.importer:
     class: Drupal\simplytest_projects\ProjectImporter
     arguments: ['@http_client', '@simplytest_projects.fetcher', '@logger.channel.default']
+
+  Drupal\simplytest_projects\EventSubscriber\ModifyMaxAgeResponseSubscriber:
+    class: Drupal\simplytest_projects\EventSubscriber\ModifyMaxAgeResponseSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/web/modules/custom/simplytest_projects/src/Controller/SimplyTestProjects.php
+++ b/web/modules/custom/simplytest_projects/src/Controller/SimplyTestProjects.php
@@ -116,6 +116,7 @@ class SimplyTestProjects extends ControllerBase implements ContainerInjectionInt
     $response = new CacheableJsonResponse([
       'list' => $versions
     ]);
+    $response->setMaxAge(300);
     $response->getCacheableMetadata()->addCacheTags(["project_versions:{$project}"]);
     return $response;
   }
@@ -138,6 +139,7 @@ class SimplyTestProjects extends ControllerBase implements ContainerInjectionInt
     $response = new CacheableJsonResponse([
       'list' => $results
     ]);
+    $response->setMaxAge(300);
     $response->getCacheableMetadata()->addCacheTags(['core_versions', "core_versions:$major_version"]);
     return $response;
   }
@@ -151,6 +153,7 @@ class SimplyTestProjects extends ControllerBase implements ContainerInjectionInt
     $response = new CacheableJsonResponse([
       'list' => $results
     ]);
+    $response->setMaxAge(300);
     $cid = implode(':', ['core_compatibility', $project, $version]);
     // @todo loop over results to find core version tabs to attach here.
     $cache_tags = ['core_versions', $cid];

--- a/web/modules/custom/simplytest_projects/src/Controller/SimplyTestProjects.php
+++ b/web/modules/custom/simplytest_projects/src/Controller/SimplyTestProjects.php
@@ -3,77 +3,34 @@
 namespace Drupal\simplytest_projects\Controller;
 
 use Drupal\Core\Cache\CacheableJsonResponse;
-use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\simplytest_projects\ProjectVersionManager;
 use Drupal\simplytest_projects\ProjectFetcher;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
  * Returns responses for config module routes.
  */
-class SimplyTestProjects extends ControllerBase implements ContainerInjectionInterface {
+class SimplyTestProjects implements ContainerInjectionInterface {
 
   /**
-   * The entity type manager.
+   * Constructs a new SimplyTestProjects object.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The request object.
-   *
-   * @var \Symfony\Component\HttpFoundation\RequestStack
-   */
-  protected $requestStack;
-
-  /**
-   * The simplytest project fetcher object.
-   *
-   * @var \Drupal\simplytest_projects\ProjectFetcher
-   */
-  protected $projectFetcher;
-
-  /**
-   * The core version manager.
-   *
-   * @var \Drupal\simplytest_projects\CoreVersionManager
-   */
-  private $coreVersionManager;
-
-  /**
-   * The project version manager.
-   *
-   * @var \Drupal\simplytest_projects\ProjectVersionManager
-   */
-  private $projectVersionManager;
-
-  /**
-   * Constructs a new ViewEditForm object.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
-   *   The request stack object.
-   * @param \Drupal\simplytest_projects\ProjectFetcher $simplytest_project_fetcher
+   * @param \Drupal\simplytest_projects\ProjectFetcher $projectFetcher
    *   The project fetcher.
-   * @param \Drupal\simplytest_projects\CoreVersionManager $core_version_manager
+   * @param \Drupal\simplytest_projects\CoreVersionManager $coreVersionManager
    *   The core version manager.
-   * @param \Drupal\simplytest_projects\ProjectVersionManager $project_version_manager
+   * @param \Drupal\simplytest_projects\ProjectVersionManager $projectVersionManager
    *   The project version manager.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, RequestStack $requestStack, ProjectFetcher $simplytest_project_fetcher, CoreVersionManager $core_version_manager, ProjectVersionManager $project_version_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-    $this->requestStack = $requestStack;
-    $this->projectFetcher = $simplytest_project_fetcher;
-    $this->coreVersionManager = $core_version_manager;
-    $this->projectVersionManager = $project_version_manager;
+  public function __construct(
+    private readonly ProjectFetcher $projectFetcher,
+    private readonly CoreVersionManager $coreVersionManager,
+    private readonly ProjectVersionManager $projectVersionManager
+  ) {
   }
 
   /**
@@ -81,8 +38,6 @@ class SimplyTestProjects extends ControllerBase implements ContainerInjectionInt
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('entity_type.manager'),
-      $container->get('request_stack'),
       $container->get('simplytest_projects.fetcher'),
       $container->get('simplytest_projects.core_version_manager'),
       $container->get('simplytest_projects.project_version_manager')
@@ -98,8 +53,7 @@ class SimplyTestProjects extends ControllerBase implements ContainerInjectionInt
       if (!$matches = $this->projectFetcher->searchFromProjects($string)) {
         $string = str_replace(' ', '_', $string);
         if ($project = $this->projectFetcher->fetchProject($string)) {
-          unset($project['creator']);
-          unset($project['usage']);
+          unset($project['creator'], $project['usage']);
           $matches = [$project];
         }
       }
@@ -116,7 +70,6 @@ class SimplyTestProjects extends ControllerBase implements ContainerInjectionInt
     $response = new CacheableJsonResponse([
       'list' => $versions
     ]);
-    $response->setMaxAge(300);
     $response->getCacheableMetadata()->addCacheTags(["project_versions:{$project}"]);
     return $response;
   }
@@ -139,7 +92,6 @@ class SimplyTestProjects extends ControllerBase implements ContainerInjectionInt
     $response = new CacheableJsonResponse([
       'list' => $results
     ]);
-    $response->setMaxAge(300);
     $response->getCacheableMetadata()->addCacheTags(['core_versions', "core_versions:$major_version"]);
     return $response;
   }
@@ -153,7 +105,6 @@ class SimplyTestProjects extends ControllerBase implements ContainerInjectionInt
     $response = new CacheableJsonResponse([
       'list' => $results
     ]);
-    $response->setMaxAge(300);
     $cid = implode(':', ['core_compatibility', $project, $version]);
     // @todo loop over results to find core version tabs to attach here.
     $cache_tags = ['core_versions', $cid];

--- a/web/modules/custom/simplytest_projects/src/EventSubscriber/ModifyMaxAgeResponseSubscriber.php
+++ b/web/modules/custom/simplytest_projects/src/EventSubscriber/ModifyMaxAgeResponseSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\simplytest_projects\EventSubscriber;
+
+use Drupal\Core\Cache\CacheableResponseInterface;
+use Drupal\Core\Routing\RouteObjectInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class ModifyMaxAgeResponseSubscriber implements EventSubscriberInterface {
+
+  public static function getSubscribedEvents() {
+    return [
+      // Run after FinishResponseSubscriber.
+      KernelEvents::RESPONSE => ['onResponse', 10],
+    ];
+  }
+
+  public function onResponse(ResponseEvent $event) {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+    $response = $event->getResponse();
+    if (!$response instanceof CacheableResponseInterface) {
+      return;
+    }
+    $route_name = $event->getRequest()->attributes->get(RouteObjectInterface::ROUTE_NAME, '');
+    if (!str_starts_with($route_name, 'simplytest_projects')) {
+      return;
+    }
+    // Change the response max-age to 300, but do not modify Expires so that
+    // page_cache is still permanent.
+    $response->setMaxAge(300);
+  }
+
+}


### PR DESCRIPTION
Allow page_cache to keep the cache, however, for proper invalidation.

fixes #231
