### PR TITLE
Fix pre-configured project route

### DIFF
--- a/web/modules/custom/simplytest_launch/src/Controller/SimplyTestLaunch.php
+++ b/web/modules/custom/simplytest_launch/src/Controller/SimplyTestLaunch.php
@@ -148,7 +148,7 @@ class SimplyTestLaunch implements ContainerInjectionInterface {
   private function validateSubmission($data) {
     // @todo Flood protection preflight check (IP based, possibly a problem.)
     try {
-      $definition = $this->typeDataManager->create(InstanceLaunchDefinition::create(), $data);
+      $definition = $this->typedDataManager->create(InstanceLaunchDefinition::create(), $data);
     }
     catch (\Throwable $e) {
       throw new ServiceUnavailableHttpException(null, $e->getMessage());

--- a/web/modules/custom/simplytest_launch/src/Controller/SimplyTestLaunch.php
+++ b/web/modules/custom/simplytest_launch/src/Controller/SimplyTestLaunch.php
@@ -106,7 +106,7 @@ class SimplyTestLaunch implements ContainerInjectionInterface {
 
     $cacheable_metadata = new CacheableMetadata();
     $cacheable_metadata->addCacheContexts(['url.query_args']);
-    $cacheable_metadata->addCacheContexts(["project_versions:$project"]);
+    $cacheable_metadata->addCacheTags(["project_versions:$project"]);
     $response->addCacheableDependency($cacheable_metadata);
     return $response;
   }


### PR DESCRIPTION
This doesn't fix an issue with our autocomplete and auto-import. But it does fix going to /project/{PROJECT} and having it be auto-imported.
