### PR TITLE
Preparing custom modules and themes for D10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     },
     "require-dev": {
         "drupal/core-dev": "^9.5",
-        "phpspec/prophecy-phpunit": "^2"
+        "phpspec/prophecy-phpunit": "^2.0"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     },
     "require-dev": {
         "drupal/core-dev": "^9.5",
-        "phpspec/prophecy-phpunit": "^2.0"
+        "phpspec/prophecy-phpunit": "^2"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f264994da36e02570fdc817184096db3",
+    "content-hash": "198008c47906d5bf3f21c5549c676f8d",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",

--- a/web/modules/custom/simplytest_import/simplytest_import.info.yml
+++ b/web/modules/custom/simplytest_import/simplytest_import.info.yml
@@ -2,7 +2,7 @@ name: 'SimplyTest Import'
 description: 'Fetching data from drupal.org and importing the project automatically.'
 type: module
 package: Simplytest
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - simplytest_projects
 lifecycle: deprecated

--- a/web/modules/custom/simplytest_launch/simplytest_launch.info.yml
+++ b/web/modules/custom/simplytest_launch/simplytest_launch.info.yml
@@ -2,7 +2,7 @@ name: SimplyTest Launch
 description: Basic submission form of simplytest.me.
 type: module
 package: Simplytest
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - simplytest:simplytest_projects
   - simplytest:simplytest_tugboat

--- a/web/modules/custom/simplytest_messages/simplytest_messages.info.yml
+++ b/web/modules/custom/simplytest_messages/simplytest_messages.info.yml
@@ -3,4 +3,4 @@ type: module
 description: Display various warning message.
 package: Custom
 core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8 || ^9 || ^10

--- a/web/modules/custom/simplytest_ocd/simplytest_ocd.info.yml
+++ b/web/modules/custom/simplytest_ocd/simplytest_ocd.info.yml
@@ -2,4 +2,4 @@ name: 'SimplyTest OCD'
 description: 'One click demos.'
 type: module
 package: Simplytest
-core_version_requirement: ^9
+core_version_requirement: ^9  || ^10

--- a/web/modules/custom/simplytest_ocd/tests/src/Unit/OneClickDemoConfigTestBase.php
+++ b/web/modules/custom/simplytest_ocd/tests/src/Unit/OneClickDemoConfigTestBase.php
@@ -5,11 +5,14 @@ namespace Drupal\Tests\simplytest_ocd\Unit;
 use Drupal\simplytest_ocd\OneClickDemoPluginManager;
 use Drupal\simplytest_tugboat\PreviewConfigGenerator;
 use Drupal\Tests\UnitTestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * Base test class for testing Tugboat configuration generation.
  */
 abstract class OneClickDemoConfigTestBase extends UnitTestCase {
+
+  use ProphecyTrait;
 
   protected static $pluginId;
   protected static $pluginClass;

--- a/web/modules/custom/simplytest_projects/simplytest_projects.info.yml
+++ b/web/modules/custom/simplytest_projects/simplytest_projects.info.yml
@@ -2,6 +2,6 @@ name: SimplyTest Projects
 description: Entity for drupal projects, and fetcher for retreiving project metadata.
 type: module
 package: Simplytest
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:update

--- a/web/modules/custom/simplytest_projects/src/ProjectFetcher.php
+++ b/web/modules/custom/simplytest_projects/src/ProjectFetcher.php
@@ -199,6 +199,7 @@ class ProjectFetcher {
     $project_ids = $this->entityTypeManager
       ->getStorage('simplytest_project')
       ->getQuery('AND')
+      ->accessCheck(FALSE)
       ->condition('shortname', $shortname)
       ->execute();
 

--- a/web/modules/custom/simplytest_projects/tests/modules/simplytest_projects_test/simplytest_projects_test.info.yml
+++ b/web/modules/custom/simplytest_projects/tests/modules/simplytest_projects_test/simplytest_projects_test.info.yml
@@ -1,6 +1,6 @@
 name: SimplyTest Projects Test
 type: module
 package: Simplytest
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - simplytest:simplytest_projects

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectFetcherTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectFetcherTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Drupal\Tests\simplytesyt_projects\Kernel;
+namespace Drupal\Tests\simplytest_projects\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_projects\CoreVersionManager;
@@ -21,7 +21,7 @@ final class ProjectFetcherTest extends KernelTestBase {
     'simplytest_projects_test',
   ];
 
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
     $this->installEntitySchema('simplytest_project');
     $this->installSchema('simplytest_projects', CoreVersionManager::TABLE_NAME);

--- a/web/modules/custom/simplytest_projects/tests/src/Traits/MockedReleaseHttpClientTrait.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Traits/MockedReleaseHttpClientTrait.php
@@ -4,8 +4,12 @@ namespace Drupal\Tests\simplytest_projects\Traits;
 
 use GuzzleHttp\Client;
 use Psr\Http\Message\ResponseInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
+
 
 trait MockedReleaseHttpClientTrait {
+
+  use ProphecyTrait;
 
   protected function getMockedHttpClient(): Client {
     $client = $this->prophesize(Client::class);

--- a/web/modules/custom/simplytest_tugboat/simplytest_tugboat.info.yml
+++ b/web/modules/custom/simplytest_tugboat/simplytest_tugboat.info.yml
@@ -2,7 +2,7 @@ name: SimplyTest Tugboat
 type: module
 description: Submits instances to Tugboat QA
 package: Simplytest
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - simplytest:simplytest_projects
   - simplytest:simplytest_ocd

--- a/web/modules/custom/simplytest_tugboat/tests/src/Unit/InstanceManagerTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Unit/InstanceManagerTest.php
@@ -16,8 +16,11 @@ use Drupal\Tests\UnitTestCase;
 use Drupal\tugboat\TugboatClient;
 use GuzzleHttp\HandlerStack;
 use Psr\Log\NullLogger;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 final class InstanceManagerTest extends UnitTestCase {
+
+  use ProphecyTrait;
 
   private InstanceManager $instanceManager;
   private TugboatClient $tugboatClient;

--- a/web/modules/custom/simplytest_tugboat/tests/src/Unit/TugboatConfigTestBase.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Unit/TugboatConfigTestBase.php
@@ -5,11 +5,15 @@ namespace Drupal\Tests\simplytest_tugboat\Unit;
 use Drupal\simplytest_ocd\OneClickDemoPluginManager;
 use Drupal\simplytest_tugboat\PreviewConfigGenerator;
 use Drupal\Tests\UnitTestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
 
 /**
  * Base test class for testing Tugboat configuration generation.
  */
 abstract class TugboatConfigTestBase extends UnitTestCase {
+
+  use ProphecyTrait;
 
   /**
    * The preview config generator.

--- a/web/profiles/simplytest/simplytest.info.yml
+++ b/web/profiles/simplytest/simplytest.info.yml
@@ -1,7 +1,7 @@
 name: Simplytest
 type: profile
 description: Installation profile for simplytest.me.
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 
 distribution:
   name: Simplytest

--- a/web/themes/simplytest_theme/simplytest_theme.info.yml
+++ b/web/themes/simplytest_theme/simplytest_theme.info.yml
@@ -1,7 +1,7 @@
 name: SimpyTest
 type: theme
 description: 'SimplyTest Custom Theme'
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 base theme: claro
 
 regions:

--- a/web/themes/simplytest_theme/theme-settings.php
+++ b/web/themes/simplytest_theme/theme-settings.php
@@ -46,7 +46,7 @@ function _simplytest_theme_header_bg_validate($element, FormStateInterface $form
     $file = $files[0];
     $file->setPermanent();
     $file->save();
-    $file_url = file_create_url($file->getFileUri());
+    $file_url = \Drupal::service('file_url_generator')->generateAbsoluteString($file->getFileUri());
     $file_url = str_ireplace($base_url, '', $file_url);
     $form_state->setValue('header_bg_file', $file_url);
   }


### PR DESCRIPTION
The modules and themes of simplytestme need to be updated to
    take into account deprecated code. This will allow us to subsequently
    upgrade to Drupal 10 with the least amount of work.