### PR TITLE
Fix error ProjectFetcher.php

### DIFF
--- a/web/modules/custom/simplytest_projects/src/ProjectFetcher.php
+++ b/web/modules/custom/simplytest_projects/src/ProjectFetcher.php
@@ -156,7 +156,7 @@ class ProjectFetcher {
       'type' => $type,
       'creator' => $creator,
       'usage' => array_reduce(
-        $project_data['project_usage'] ?? 0,
+        $project_data['project_usage'] ?? [],
         static fn (int $carry, $usage) => $carry + (int) $usage, 0
       ),
     ];


### PR DESCRIPTION
In case the project_usage is not there, array_reduce expects an array, not an int.