### PR TITLE
Update ddev to reflect latest changes.

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,75 +1,110 @@
 name: simplytestme
-type: drupal9
+type: drupal10
 docroot: web
 php_version: "8.2"
 webserver_type: nginx-fpm
-router_http_port: "80"
-router_https_port: "443"
 xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
-mariadb_version: "10.3"
-mysql_version: ""
-provider: default
+database:
+    type: mariadb
+    version: "10.3"
 use_dns_when_possible: true
 composer_version: "2"
+web_environment: []
+corepack_enable: false
 
-
-# This config.yaml was created with ddev version v1.16.4
-# webimage: drud/ddev-webserver:v1.16.3
-# dbimage: drud/ddev-dbserver-mariadb-10.2:v1.16.0
-# dbaimage: phpmyadmin:5
-# However we do not recommend explicitly wiring these images into the
-# config.yaml as they may break future versions of ddev.
-# You can update this config.yaml using 'ddev config'.
-
-# Key features of ddev's config.yaml:
+# Key features of DDEV's config.yaml:
 
 # name: <projectname> # Name of the project, automatically provides
 #   http://projectname.ddev.site and https://projectname.ddev.site
 
-# type: <projecttype>  # drupal6/7/8, backdrop, typo3, wordpress, php
+# type: <projecttype>  # backdrop, cakephp, craftcms, drupal, drupal6, drupal7, drupal8, drupal9, drupal10, drupal11, generic, laravel, magento, magento2, php, shopware6, silverstripe, symfony, typo3, wordpress
+# See https://ddev.readthedocs.io/en/stable/users/quickstart/ for more
+# information on the different project types
 
 # docroot: <relative_path> # Relative path to the directory containing index.php.
 
-# php_version: "7.3"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3", "7.4" "8.0"
+# php_version: "8.3"  # PHP version to use, "5.6" through "8.4"
 
-# You can explicitly specify the webimage, dbimage, dbaimage lines but this
-# is not recommended, as the images are often closely tied to ddev's' behavior,
+# You can explicitly specify the webimage but this
+# is not recommended, as the images are often closely tied to DDEV's' behavior,
 # so this can break upgrades.
 
 # webimage: <docker_image>  # nginx/php docker image.
-# dbimage: <docker_image>  # mariadb docker image.
-# dbaimage: <docker_image>
 
-# mariadb_version and mysql_version
-# ddev can use many versions of mariadb and mysql
-# However these directives are mutually exclusive
-# mariadb_version: 10.2
-# mysql_version: 8.0
+# database:
+#   type: <dbtype> # mysql, mariadb, postgres
+#   version: <version> # database version, like "10.11" or "8.0"
+#   MariaDB versions can be 5.5-10.8, 10.11, and 11.4.
+#   MySQL versions can be 5.5-8.0.
+#   PostgreSQL versions can be 9-17.
 
-# router_http_port: <port>  # Port to be used for http (defaults to port 80)
-# router_https_port: <port> # Port for https (defaults to 443)
+# router_http_port: <port>  # Port to be used for http (defaults to global configuration, usually 80)
+# router_https_port: <port> # Port for https (defaults to global configuration, usually 443)
 
-# xdebug_enabled: false  # Set to true to enable xdebug and "ddev start" or "ddev restart"
+# xdebug_enabled: false  # Set to true to enable Xdebug and "ddev start" or "ddev restart"
 # Note that for most people the commands
-# "ddev xdebug" to enable xdebug and "ddev xdebug off" to disable it work better,
-# as leaving xdebug enabled all the time is a big performance hit.
+# "ddev xdebug" to enable Xdebug and "ddev xdebug off" to disable it work better,
+# as leaving Xdebug enabled all the time is a big performance hit.
 
-# webserver_type: nginx-fpm  # or apache-fpm
+# xhgui_https_port: 8142
+# Can be used to change the router https port for xhgui application
+# Very rarely used
+
+# xhgui_http_port: 8143
+# Can be used to change the router http port for xhgui application
+# Very rarely used
+
+# host_xhgui_port: 8142
+# Can be used to change the host binding port of the xhgui
+# application. Rarely used; only when port conflict and 
+# bind_all_ports is used (normally with router disabled)
+
+# xhprof_enabled: false  # Set to true to enable Xhprof and "ddev start" or "ddev restart"
+# Note that for most people the commands
+# "ddev xhprof" to enable Xhprof and "ddev xhprof off" to disable it work better,
+# as leaving Xhprof enabled all the time is a big performance hit.
+
+# xhprof_mode: [prepend|xhgui|global]
+# Set to "xhgui" to enable XHGui features
+# "xhgui" will become default in a future major release
+
+# webserver_type: nginx-fpm, apache-fpm, generic
 
 # timezone: Europe/Berlin
+# If timezone is unset, DDEV will attempt to derive it from the host system timezone
+# using the $TZ environment variable or the /etc/localtime symlink.
 # This is the timezone used in the containers and by PHP;
 # it can be set to any valid timezone,
 # see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 # For example Europe/Dublin or MST7MDT
 
+# composer_root: <relative_path>
+# Relative path to the Composer root directory from the project root. This is
+# the directory which contains the composer.json and where all Composer related
+# commands are executed.
+
 # composer_version: "2"
-# if composer_version:"" it will use the current ddev default composer release.
-# It can also be set to "1", to get most recent composer v1
-# or "2" for most recent composer v2.
-# It can be set to any existing specific composer version.
-# After first project 'ddev start' this will not be updated until it changes
+# You can set it to "" or "2" (default) for Composer v2 or "1" for Composer v1
+# to use the latest major version available at the time your container is built.
+# It is also possible to use each other Composer version channel. This includes:
+#   - 2.2 (latest Composer LTS version)
+#   - stable
+#   - preview
+#   - snapshot
+# Alternatively, an explicit Composer version may be specified, for example "2.2.18".
+# To reinstall Composer after the image was built, run "ddev debug rebuild".
+
+# nodejs_version: "22"
+# change from the default system Node.js version to any other version.
+# See https://ddev.readthedocs.io/en/stable/users/configuration/config/#nodejs_version for more information
+# and https://www.npmjs.com/package/n#specifying-nodejs-versions for the full documentation,
+# Note that using of 'ddev nvm' is discouraged because "nodejs_version" is much easier to use,
+# can specify any version, and is more robust than using 'nvm'.
+
+# corepack_enable: false
+# Change to 'true' to 'corepack enable' and gain access to latest versions of yarn/pnpm
 
 # additional_hostnames:
 #  - somename
@@ -83,8 +118,26 @@ composer_version: "2"
 # would provide http and https URLs for "example.com" and "sub1.example.com"
 # Please take care with this because it can cause great confusion.
 
-# upload_dir: custom/upload/dir
-# would set the destination path for ddev import-files to custom/upload/dir.
+# upload_dirs: "custom/upload/dir"
+#
+# upload_dirs:
+#   - custom/upload/dir
+#   - ../private
+#
+# would set the destination paths for ddev import-files to <docroot>/custom/upload/dir
+# When Mutagen is enabled this path is bind-mounted so that all the files
+# in the upload_dirs don't have to be synced into Mutagen.
+
+# disable_upload_dirs_warning: false
+# If true, turns off the normal warning that says
+# "You have Mutagen enabled and your 'php' project type doesn't have upload_dirs set"
+
+# ddev_version_constraint: ""
+# Example:
+# ddev_version_constraint: ">= 1.22.4"
+# This will enforce that the running ddev version is within this constraint.
+# See https://github.com/Masterminds/semver#checking-version-constraints for
+# supported constraint formats
 
 # working_dir:
 #   web: /var/www/html
@@ -93,15 +146,28 @@ composer_version: "2"
 # These values specify the destination directory for ddev ssh and the
 # directory in which commands passed into ddev exec are run.
 
-# omit_containers: [db, dba, ddev-ssh-agent]
+# omit_containers: [db, ddev-ssh-agent]
 # Currently only these containers are supported. Some containers can also be
 # omitted globally in the ~/.ddev/global_config.yaml. Note that if you omit
-# the "db" container, several standard features of ddev that access the
-# database container will be unusable.
+# the "db" container, several standard features of DDEV that access the
+# database container will be unusable. In the global configuration it is also
+# possible to omit ddev-router, but not here.
 
-# nfs_mount_enabled: false
-# Great performance improvement but requires host configuration first.
-# See https://ddev.readthedocs.io/en/stable/users/performance/#using-nfs-to-mount-the-project-into-the-container
+# performance_mode: "global"
+# DDEV offers performance optimization strategies to improve the filesystem
+# performance depending on your host system. Should be configured globally.
+#
+# If set, will override the global config. Possible values are:
+#   - "global":  uses the value from the global config.
+#   - "none":    disables performance optimization for this project.
+#   - "mutagen": enables Mutagen for this project.
+#   - "nfs":     enables NFS for this project.
+#
+# See https://ddev.readthedocs.io/en/stable/users/install/performance/#nfs
+# See https://ddev.readthedocs.io/en/stable/users/install/performance/#mutagen
+
+# fail_on_hook_fail: False
+# Decide whether 'ddev start' should be interrupted by a failing hook
 
 # host_https_port: "59002"
 # The host port binding for https can be explicitly specified. It is
@@ -119,15 +185,15 @@ composer_version: "2"
 # The host port binding for the ddev-dbserver can be explicitly specified. It is dynamic
 # unless explicitly specified.
 
-# phpmyadmin_port: "8036"
-# phpmyadmin_https_port: "8037"
-# The PHPMyAdmin ports can be changed from the default 8036 and 8037
+# mailpit_http_port: "8025"
+# mailpit_https_port: "8026"
+# The Mailpit ports can be changed from the default 8025 and 8026
 
-# mailhog_port: "8025"
-# mailhog_https_port: "8026"
-# The MailHog ports can be changed from the default 8025 and 8026
+# host_mailpit_port: "8025"
+# The mailpit port is not normally bound on the host at all, instead being routed
+# through ddev-router, but it can be bound directly to localhost if specified here.
 
-# webimage_extra_packages: [php7.3-tidy, php-bcmath]
+# webimage_extra_packages: [php7.4-tidy, php-bcmath]
 # Extra Debian packages that are needed in the webimage can be added here
 
 # dbimage_extra_packages: [telnet,netcat]
@@ -145,30 +211,91 @@ composer_version: "2"
 # If you prefer you can change this to "ddev.local" to preserve
 # pre-v1.9 behavior.
 
-# ngrok_args: --subdomain mysite --auth username:pass
+# ngrok_args: --basic-auth username:pass1234
 # Provide extra flags to the "ngrok http" command, see
-# https://ngrok.com/docs#http or run "ngrok http -h"
+# https://ngrok.com/docs/ngrok-agent/config or run "ngrok http -h"
 
 # disable_settings_management: false
-# If true, ddev will not create CMS-specific settings files like
-# Drupal's settings.php/settings.ddev.php or TYPO3's AdditionalSettings.php
+# If true, DDEV will not create CMS-specific settings files like
+# Drupal's settings.php/settings.ddev.php or TYPO3's additional.php
 # In this case the user must provide all such settings.
 
+# You can inject environment variables into the web container with:
+# web_environment:
+#     - SOMEENV=somevalue
+#     - SOMEOTHERENV=someothervalue
+
 # no_project_mount: false
-# (Experimental) If true, ddev will not mount the project into the web container;
+# (Experimental) If true, DDEV will not mount the project into the web container;
 # the user is responsible for mounting it manually or via a script.
 # This is to enable experimentation with alternate file mounting strategies.
 # For advanced users only!
 
-# provider: default # Currently either "default" or "pantheon"
+# bind_all_interfaces: false
+# If true, host ports will be bound on all network interfaces,
+# not the localhost interface only. This means that ports
+# will be available on the local network if the host firewall
+# allows it.
+
+# default_container_timeout: 120
+# The default time that DDEV waits for all containers to become ready can be increased from
+# the default 120. This helps in importing huge databases, for example.
+
+#web_extra_exposed_ports:
+#- name: nodejs
+#  container_port: 3000
+#  http_port: 2999
+#  https_port: 3000
+#- name: something
+#  container_port: 4000
+#  https_port: 4000
+#  http_port: 3999
+# Allows a set of extra ports to be exposed via ddev-router
+# Fill in all three fields even if you don’t intend to use the https_port!
+# If you don’t add https_port, then it defaults to 0 and ddev-router will fail to start.
 #
-# Many ddev commands can be extended to run tasks before or after the
-# ddev command is executed, for example "post-start", "post-import-db",
+# The port behavior on the ddev-webserver must be arranged separately, for example
+# using web_extra_daemons.
+# For example, with a web app on port 3000 inside the container, this config would
+# expose that web app on https://<project>.ddev.site:9999 and http://<project>.ddev.site:9998
+# web_extra_exposed_ports:
+#  - name: myapp
+#    container_port: 3000
+#    http_port: 9998
+#    https_port: 9999
+
+#web_extra_daemons:
+#- name: "http-1"
+#  command: "/var/www/html/node_modules/.bin/http-server -p 3000"
+#  directory: /var/www/html
+#- name: "http-2"
+#  command: "/var/www/html/node_modules/.bin/http-server /var/www/html/sub -p 3000"
+#  directory: /var/www/html
+
+# override_config: false
+# By default, config.*.yaml files are *merged* into the configuration
+# But this means that some things can't be overridden
+# For example, if you have 'use_dns_when_possible: true'' you can't override it with a merge
+# and you can't erase existing hooks or all environment variables.
+# However, with "override_config: true" in a particular config.*.yaml file,
+# 'use_dns_when_possible: false' can override the existing values, and
+# hooks:
+#   post-start: []
+# or
+# web_environment: []
+# or
+# additional_hostnames: []
+# can have their intended affect. 'override_config' affects only behavior of the
+# config.*.yaml file it exists in.
+
+# Many DDEV commands can be extended to run tasks before or after the
+# DDEV command is executed, for example "post-start", "post-import-db",
 # "pre-composer", "post-composer"
-# See https://ddev.readthedocs.io/en/stable/users/extending-commands/ for more
+# See https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/ for more
 # information on the commands that can be extended and the tasks you can define
 # for them. Example:
 #hooks:
 # post-import-db:
-#   - exec: drush cr
-#   - exec: drush updb
+#   - exec: drush sql:sanitize
+#   - exec: drush updatedb
+#   - exec: drush cache:rebuild

--- a/.ddev/docker-compose.env.yaml
+++ b/.ddev/docker-compose.env.yaml
@@ -1,4 +1,3 @@
-version: '3.6'
 services:
   web:
     environment:


### PR DESCRIPTION
DDEV has been updated and as such the config file requirements have slightly changed.

Secondary to that, the --project-type is incorrect; it should be set to drupal10 to match the version of Drupal that is installed when built.

