### PR TITLE
Fix PHPStan failure on main

### DIFF
--- a/web/modules/custom/simplytest_launch/src/Exception/UnprocessableHttpEntityException.php
+++ b/web/modules/custom/simplytest_launch/src/Exception/UnprocessableHttpEntityException.php
@@ -38,7 +38,7 @@ class UnprocessableHttpEntityException extends HttpException {
    * @param int $code
    *   The HTTP status code associated with the request. Defaults to zero.
    */
-  public function __construct(\Exception $previous = NULL, array $headers = [], $code = 0) {
+  public function __construct(?\Exception $previous = NULL, array $headers = [], $code = 0) {
     parent::__construct(422, "Unprocessable Entity: validation failed.", $previous, $headers, $code);
   }
 

--- a/web/modules/custom/simplytest_projects/src/ProjectFetcher.php
+++ b/web/modules/custom/simplytest_projects/src/ProjectFetcher.php
@@ -65,6 +65,9 @@ class ProjectFetcher {
 
   /**
    * Fetches and stores the project while fetchProject() holds the lock.
+   *
+   * @return array{title: string, shortname: string, sandbox: bool, type: string, creator: string|null, usage: int}|null
+   *   The saved project data, or NULL if the project could not be fetched.
    */
   private function doFetchProject(string $shortname): ?array {
     // Ensure the shortname is always lowercase. The Drupal.org API is not


### PR DESCRIPTION
## What changed

PHPStan on `main` fails after #580. The lock refactor in `ProjectFetcher` added a private `doFetchProject()` method returning `?array` with no value type. The old public `fetchProject()` has the same signature but is covered by `phpstan-baseline.neon`; the new method is not.

## How

Added an array shape instead of a baseline entry:

```php
@return array{title: string, shortname: string, sandbox: bool, type: string, creator: string|null, usage: int}|null
```

Second commit: `UnprocessableHttpEntityException::__construct()` declared `\Exception $previous = NULL`, implicitly nullable and deprecated since PHP 8.4. Now `?\Exception`. CI's PHP does not flag this yet, but PHP 8.5 locally does, and it will fail CI on the next runner PHP bump.

## Testing

`php vendor/bin/phpstan.phar --memory-limit=1G` reports no errors on PHP 8.5.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)