### PR TITLE
Fix duplicate YAML merge keys in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,8 +55,7 @@ services:
       lagoon.type: nginx-php-persistent
       lagoon.persistent: /app/web/sites/default/files/ # define where the persistent storage should be mounted too
       lando.type: nginx-drupal
-    << : *default-volumes # loads the defined volumes from the top
-    << : *default-user # uses the defined user from top
+    << : [*default-volumes, *default-user] # loads the defined volumes and user from the top
     depends_on:
       - cli # basically just tells docker-compose to build the cli first
     environment:
@@ -77,8 +76,7 @@ services:
       lagoon.name: nginx # we want this service be part of the nginx pod in Lagoon
       lagoon.persistent: /app/web/sites/default/files/ # define where the persistent storage should be mounted too
       lando.type: php-fpm
-    << : *default-volumes # loads the defined volumes from the top
-    << : *default-user # uses the defined user from top
+    << : [*default-volumes, *default-user] # loads the defined volumes and user from the top
     depends_on:
       - cli # basically just tells docker-compose to build the cli first
     environment:


### PR DESCRIPTION
## What changed

The `nginx` and `php` services declared `<<` twice in the same mapping. Both now use the list form:

```yaml
<< : [*default-volumes, *default-user]
```

## Why

Every Lagoon build since at least January finishes as `deployCompletedWithWarnings`. The build log points at the compose file:

```
ERR: yaml: unmarshal errors:
  line 59: mapping key "<<" already defined at line 58
  line 81: mapping key "<<" already defined at line 80
```

Duplicate `<<` keys are invalid YAML; parsers that tolerate them keep only one merge, so the `user: '1000'` merge was likely being dropped on those services.

## Testing

`docker compose config -q` parses the file with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)