### PR TITLE
Add CLAUDE.md, project skills, and fix rector job label

### DIFF
--- a/.claude/skills/checks/SKILL.md
+++ b/.claude/skills/checks/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: checks
+description: Run the local quality gates that mirror CI before pushing — PHPStan, Rector, PHPUnit with the 85% coverage gate. Use before opening a PR, when the user asks to "run the checks", or when diagnosing a red CI run on GitHub Actions.
+---
+
+# Local quality gates
+
+CI (`.github/workflows/main.yml`) runs five jobs: `site:install`, `phpstan`, `rector`, `phpunit`, `cypress`. The first four have exact local equivalents; run them in this order (fastest feedback first):
+
+```bash
+php vendor/bin/phpstan.phar --memory-limit=1G   # 1G is required locally; default 128M crashes workers
+vendor/bin/rector --dry-run                      # CI runs without --dry-run but must produce no diff
+composer tests                                   # PHPUnit, no coverage — fast iteration
+composer test:coverage                           # the real gate: coverage report + 85% threshold
+```
+
+Run a single test file while iterating:
+
+```bash
+php vendor/bin/phpunit web/modules/custom/<module>/tests/src/Kernel/<Test>.php
+```
+
+## Rules
+
+- PHPStan is level 6 + `bleedingEdge` with `phpstan-baseline.neon`. Fix new findings with real types (array shapes, explicit `?Type` nullability); never grow the baseline for new code.
+- The coverage gate (`scripts/coverage-check.php`) fails below 85% line coverage on `web/modules/custom`. New code needs Kernel or Unit tests — mock HTTP through `MockedHttpMiddleware` in `simplytest_projects_test`, never the network.
+- Local PHP may be newer than CI's (CI pins PHP 8.3). A deprecation PHPStan flags locally but CI misses is still worth fixing — it fails CI on the next runner bump.
+
+## Debugging a red CI run
+
+```bash
+gh run list --branch <branch> --limit 5
+gh run view <run-id> --log-failed
+gh pr checks <pr-number> --watch --interval 30
+```
+
+Cypress has no quick local equivalent — it needs a full site install. Check the uploaded `cypress` artifact (screenshots/videos) on the failed run first, and `drush watchdog:show` output in the job log.

--- a/.claude/skills/lagoon/SKILL.md
+++ b/.claude/skills/lagoon/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: lagoon
+description: Operate the simplytest.me Lagoon hosting on amazee.io — check deployments, build logs, environments, service logs, backups, and Drush tasks. Use whenever the user asks about deploys, "is it live", build failures, production logs, database dumps, or PR environments, even if they don't say "Lagoon".
+---
+
+# Lagoon operations for simplytest.me
+
+## Project context
+
+- **API project name**: `simplytest` — NOT `simplytestme-website`. The `project:` key in `.lagoon.yml` does not match the API; always pass `-p simplytest`.
+- **Lagoon instance**: `amazeeio` (default context)
+- **Production environment**: `main` → https://simplytest.me, deploy target `us2.amazee.io`
+- Every merge to `main` on GitHub auto-deploys production. Lagoon also builds an ephemeral environment per open PR (`pr-NNN`).
+
+## Authentication
+
+Run `lagoon login` first — it silently refreshes the token if already authenticated.
+
+## Common workflows
+
+Check recent deploys (statuses: `complete`, `failed`, `running`, `queued`, `cancelled`):
+
+```bash
+lagoon list deployments -p simplytest -e main --wide
+```
+
+Get a build log (the source of truth for `deployCompletedWithWarnings` — grep it for `Warning` and `WithWarnings` step markers):
+
+```bash
+lagoon get deployment -p simplytest -e main -N lagoon-build-XXXXX -L
+```
+
+List environments (watch for stale `pr-NNN` environments whose PRs are closed):
+
+```bash
+lagoon list environments -p simplytest
+```
+
+Service logs (`nginx`, `php`, `cli`, `mariadb`, `varnish`):
+
+```bash
+lagoon logs -p simplytest -e main -s php -n 100
+```
+
+Drush on production:
+
+```bash
+lagoon run custom -p simplytest -e main --command "drush <command>"
+```
+
+Trigger a deploy: `lagoon deploy latest -p simplytest -e main`
+
+SSH: `lagoon ssh -p simplytest -e main`
+
+## Backups (list → retrieve → download)
+
+```bash
+lagoon list backups -p simplytest -e main --output-json --pretty
+lagoon retrieve backup -p simplytest -e main -B <backupId>   # stage it; takes ~1 min
+lagoon get backup -p simplytest -e main -B <backupId>        # signed URL, ~5 min validity
+```
+
+Find the latest entry with the right `source` (`mariadb` or `files`); if `restore.status` is not `"success"`, retrieve and poll `list backups` until it is.
+
+## Destructive operations
+
+`lagoon delete environment -p simplytest -e pr-NNN --force` removes a stale PR environment. Sandboxed sessions may be unable to run deletes — hand the exact command to the user instead of retrying.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
         run: php vendor/bin/phpstan.phar
   rector:
     runs-on: ubuntu-latest
-    name: phpstan
+    name: rector
     steps:
       - uses: actions/checkout@v6
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+The source for [simplytest.me](https://simplytest.me): a Drupal site that launches throwaway Drupal evaluation sandboxes on Tugboat. Users pick a project (module, theme, distribution, or core), a version, and optional extras; the site provisions a Tugboat preview that lives for 2 hours.
+
+## Commands
+
+```bash
+composer install                # installs Drupal core, contrib, and scaffolding
+ddev si                         # install the site locally (Drush site:install simplytest)
+
+composer tests                  # PHPUnit for web/modules/custom
+php vendor/bin/phpunit web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectFetcherTest.php
+                                # run a single test file
+composer test:coverage          # PHPUnit + Clover report + 85% line-coverage gate
+                                # (scripts/coverage-check.php enforces the threshold)
+
+php vendor/bin/phpstan.phar --memory-limit=1G   # level 6 + phpstan-baseline.neon;
+                                                # the default 128M crashes locally
+vendor/bin/rector               # also enforced in CI
+
+npm run build                   # build the theme (Laravel Mix + gulp postcss)
+npm run cypress:run             # E2E tests; CI installs the site first and
+                                # serves it with PHP's built-in server
+```
+
+CI (`.github/workflows/main.yml`) runs five jobs on every push and PR to `main`: `site:install`, `phpstan`, `rector`, `phpunit` (with the coverage gate), and `cypress`.
+
+## Architecture
+
+Custom code lives in four modules under `web/modules/custom/`, all in the `Simplytest` package:
+
+- **simplytest_projects** — the data layer. Defines the `simplytest_project` entity (`SimplytestProject`) and fetches project metadata from Drupal.org: `ProjectFetcher` queries the REST API for project info, `ProjectVersionManager` and `CoreVersionManager` parse release-history XML into a custom versions table, `ProjectTypes` maps Drupal.org term names to types. Sandbox-vs-full detection, version storage, and the project autocomplete all live here.
+- **simplytest_launch** — the submission form and launch endpoint. The user-facing form is a React app (see below); this module validates the submission (constraint violations surface as `UnprocessableHttpEntityException`, a 422) and hands it to the instance manager.
+- **simplytest_tugboat** — provisions the actual sandbox through the Tugboat API and reports instance/preview state back to the frontend.
+- **simplytest_ocd** — "one click demos": preconfigured launch links.
+
+Kernel tests mock all HTTP traffic through `MockedHttpMiddleware` in the `simplytest_projects_test` support module (`web/modules/custom/simplytest_projects/tests/modules/`). Add new mocked Drupal.org responses there rather than letting tests hit the network. `BufferedLogger` in the same module captures log assertions.
+
+The install profile is `web/profiles/simplytest`, a distribution with `config_install_path: '../config/sync'` — site configuration lives in `config/sync/` at the repo root. After config changes, export with `drush config:export`.
+
+The frontend launch form is React 19 (`downshift` for autocomplete), living in the theme at `web/themes/simplytest_theme`, built with Laravel Mix plus a gulp postcss pass. `npm run build` compiles both.
+
+## Quality gates
+
+- PHPStan runs at level 6 with `bleedingEdge` and a baseline. Fix new errors properly (typed array shapes, explicit nullability) instead of adding baseline entries.
+- PHPUnit line coverage on `web/modules/custom` must stay at or above 85%.
+- All custom-module tests are Unit or Kernel tests. Keep it that way — don't add Functional tests when a Kernel test can cover the behavior.
+
+## Hosting and deploys
+
+Hosted on amazee.io Lagoon. The API project name is `simplytest` (not the `simplytestme-website` in `.lagoon.yml` — that field is not what the CLI wants), production environment `main`, deploy target `us2.amazee.io`. Every merge to `main` auto-deploys to https://simplytest.me; Lagoon also builds ephemeral environments per PR. Use `lagoon` CLI commands with `-p simplytest -e main`.


### PR DESCRIPTION
## What changed

- `CLAUDE.md`: commands, module architecture, quality gates, and Lagoon hosting notes for Claude Code sessions in this repo.
- `.claude/skills/lagoon`: Lagoon operations with the correct API project name baked in (`simplytest` — the `project:` key in `.lagoon.yml` is `simplytestme-website`, which the API does not recognize).
- `.claude/skills/checks`: the local equivalents of the CI jobs, in fastest-first order, with the PHPStan `--memory-limit=1G` and 85% coverage gate documented.
- `.github/workflows/main.yml`: the `rector` job's display name was `phpstan`, so PR checks listed phpstan twice and rector not at all. Now labeled `rector`.

## Testing

Docs plus a job label rename; the renamed `rector` check appearing on this PR is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)