### PR TITLE
Report project save failures from fetchProject instead of swallowing them

### DIFF
--- a/web/modules/custom/simplytest_projects/src/ProjectFetcher.php
+++ b/web/modules/custom/simplytest_projects/src/ProjectFetcher.php
@@ -186,11 +186,25 @@ class ProjectFetcher {
       $project = SimplytestProject::create($data);
       $project->save();
     }
-    catch (EntityValidationException) {
-      // @todo decide how to handle this error if we got a dupe save.
-    }
-    catch (EntityStorageException) {
-      // @todo decide how to handle this error if we got a dupe save, somehow.
+    catch (EntityValidationException | EntityStorageException $e) {
+      // Entity storage wraps whatever preSave() threw, so unpack it to tell
+      // a duplicate apart from a real storage failure.
+      $validation = $e instanceof EntityValidationException ? $e : $e->getPrevious();
+      if ($validation instanceof EntityValidationException) {
+        // A concurrent request imported the project first. It exists, which
+        // is all the caller needs; the stored data is as fresh as ours.
+        $this->logger->notice('Skipped saving %project: it was imported concurrently.', [
+          '%project' => $shortname,
+        ]);
+        return $data;
+      }
+      // The project did not persist: callers must not report success, or the
+      // client believes in a project the autocomplete will never find.
+      $this->logger->error('Failed to save project %project: %message', [
+        '%project' => $shortname,
+        '%message' => $e->getMessage(),
+      ]);
+      return NULL;
     }
     return $data;
   }

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectFetcherTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectFetcherTest.php
@@ -274,6 +274,31 @@ final class ProjectFetcherTest extends KernelTestBase {
   }
 
   /**
+   * A duplicate import reports success and leaves the original untouched.
+   *
+   * Two lookups for the same project can race; whichever loses the save must
+   * still tell its caller the project exists, and must not disturb the row
+   * the winner created.
+   *
+   * @covers ::fetchProject
+   */
+  public function testFetchProjectDuplicateKeepsOriginal(): void {
+    self::assertNotNull($this->sut->fetchProject('token'));
+    $original_ids = $this->projectIds('token');
+    self::assertCount(1, $original_ids);
+
+    self::assertNotNull($this->sut->fetchProject('token'));
+
+    // Still exactly the one entity, with its original ID.
+    self::assertEquals($original_ids, $this->projectIds('token'));
+    $logger = $this->container->get('simplytest_projects_test.logger');
+    self::assertStringContainsString(
+      'Skipped saving token: it was imported concurrently.',
+      implode("\n", $logger->getMessages()),
+    );
+  }
+
+  /**
    * @return array<int|string, string>
    */
   private function projectIds(string $shortname): array {


### PR DESCRIPTION
## What changed

`fetchProject()` no longer swallows entity save failures. A duplicate save (two lookups racing) logs a notice and still reports success — the project exists either way. Any other storage failure logs an error and returns NULL, so the lookup endpoint 404s instead of claiming a project exists that the autocomplete will never find.

## Why

The two catch blocks were empty `@todo`s, and the CI debugging on #588 showed lookups returning 200 while the entity was absent afterward — with zero log evidence to tell when or why. Whatever that turns out to be, silent success on a failed save makes it undiagnosable.

## Testing notes

New kernel test proves the duplicate path: the losing save reports success, logs the notice, and leaves the winner's entity untouched (same single row, same ID). Full module suite (119 tests), PHPStan, Rector green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)