### PR TITLE
Show the patch field as soon as an additional project is selected

### DIFF
--- a/cypress/e2e/additional_projects.cy.js
+++ b/cypress/e2e/additional_projects.cy.js
@@ -25,4 +25,24 @@ describe('Tests additional projects and version constraints', () => {
     cy.get('#additional_project_0 select')
       .should('have.value', '2.0.1')
   })
+
+  // Regression test for #3571405: the patch field used to stay hidden until
+  // a second project was added, because onChange mutated the additional
+  // projects array in place instead of copying it.
+  it('should show a patch field as soon as an additional project is selected', function () {
+    cy.pickProject('Password Policy')
+    cy.toggleAdvancedOptions()
+    cy.get('button').contains('Add another project').click();
+    cy.get('#additional_project_0').getByLabel('Additional project name')
+      .type('Password Policy')
+      .wait(100)
+      .type(' Pwned')
+      .wait(2000)
+      .type('{downArrow}{enter}')
+
+    cy.wait(400)
+    cy.get('#additional_project_0 input[type=url]')
+      .should('exist')
+      .and('have.value', '')
+  })
 })

--- a/web/themes/simplytest_theme/lib/components/AdditionalProjects.jsx
+++ b/web/themes/simplytest_theme/lib/components/AdditionalProjects.jsx
@@ -65,7 +65,10 @@ function AdditionalProjects() {
                     changedProject.shortname ||
                   additionalProjects[k].version !== changedVersion
                 ) {
-                  const newProjects = additionalProjects;
+                  // Copy the array. Mutating it in place and passing the
+                  // same reference back makes React bail out of the render,
+                  // so the patch field below never mounts. See #3571405.
+                  const newProjects = [...additionalProjects];
                   newProjects[k] = {
                     version: changedVersion,
                     patches: [],


### PR DESCRIPTION
Fixes [#3571405](https://www.drupal.org/project/simplytest/issues/3571405).

## The bug

Add an additional project in Advanced options and no patch field appears for it. The reporter hit this in February against the old form, and it survived the rebuild in #586. I reproduced it on production with Cypress before touching anything.

Their workaround was to click "Add another project" a second time, enter the patch in the field that finally appeared, then remove the spare project. The impact is worse than a missing field: they put an Admin Toolbar patch into Drupal core's patch field and the build failed.

## Cause

`AdditionalProjects.jsx` handled `ProjectSelection`'s `onChange` like this:

```js
const newProjects = additionalProjects;  // same reference
newProjects[k] = { ... };
setAdditionalProjects(newProjects);
```

The array was mutated in place and handed back as the same reference. React compares with `Object.is`, saw no change, and bailed out of the render. The state data was correct, but the gate that mounts the field never re-ran:

```jsx
{project.shortname ? (<Patches ... />) : null}
```

`addAdditionalProject` builds a new array with a spread, so clicking it forced the render that revealed the field. That is exactly why the workaround worked. `removeExtraProject` was already correct, using `.slice()`.

## Fix

Copy the array. The equality guard already wrapping the update keeps the now-effective `setState` from looping.

## Testing

Added a regression test to `additional_projects.cy.js`. Verified it fails without the fix (`Expected to find element: #additional_project_0 input[type=url], but never found it`) and passes with it.

## Not in this PR

Two adjacent problems in the same block, left alone to keep this focused:

- `patches: []` sits before the `...changedProject` spread, so changing an additional project's version wipes any patch URLs already typed for it.
- `key={project.shortname}` is `""` for a freshly added row, so two unfilled additional projects collide on the same key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)