### PR TITLE
Keep additional project patches and give rows a stable key

### DIFF
--- a/cypress/e2e/additional_projects.cy.js
+++ b/cypress/e2e/additional_projects.cy.js
@@ -45,4 +45,80 @@ describe('Tests additional projects and version constraints', () => {
       .should('exist')
       .and('have.value', '')
   })
+  // Changing an additional project's version used to reset its patches,
+  // because onChange rebuilt the row with `patches: []`. The root project's
+  // patches survive a version change, so these should too.
+  it('should keep patches on an additional project when its version changes', function () {
+    const patchUrl = 'https://www.drupal.org/files/issues/example.patch'
+
+    cy.pickProject('Password Policy')
+    cy.toggleAdvancedOptions()
+    cy.get('button').contains('Add another project').click();
+    cy.get('#additional_project_0').getByLabel('Additional project name')
+      .type('Password Policy')
+      .wait(100)
+      .type(' Pwned')
+      .wait(2000)
+      .type('{downArrow}{enter}')
+    cy.wait(400)
+
+    cy.get('#additional_project_0 input[type=url]').type(patchUrl)
+
+    // Switch to any other release the project offers.
+    cy.get('#additional_project_0 select').then($select => {
+      const current = $select.val()
+      const other = [...$select[0].options]
+        .map(option => option.value)
+        .find(value => value && value !== current)
+      expect(other, 'a second release to switch to').to.be.a('string')
+      cy.get('#additional_project_0 select').select(other)
+    })
+    cy.wait(400)
+
+    cy.get('#additional_project_0 input[type=url]').should('have.value', patchUrl)
+  })
+
+  // Rows used to key on the shortname, which is "" until a project is picked,
+  // so two empty rows shared a key. React tolerates that here because the row
+  // ids come from the map index, so this does not reproduce a visible failure.
+  // It guards the arrangement the stable row id is meant to protect.
+  it('should render two separate rows when adding two projects before picking either', function () {
+    cy.pickProject('Password Policy')
+    cy.toggleAdvancedOptions()
+    cy.get('button').contains('Add another project').click();
+    cy.get('button').contains('Add another project').click();
+
+    cy.get('[id^="additional_project_"]').should('have.length', 2)
+    cy.get('#additional_project_0').should('exist')
+    cy.get('#additional_project_1').should('exist')
+  })
+
+  // The row id is a UI concern. The backend builds typed data from this
+  // payload and throws on properties it does not define, so this guards the
+  // strip in getLaunchPayload rather than reproducing an older bug.
+  it('should not send the internal row id in the launch payload', function () {
+    cy.intercept('POST', '**/launch-project', {
+      statusCode: 503,
+      body: { message: 'stubbed, not launching' }
+    }).as('launch')
+
+    cy.pickProject('Password Policy')
+    cy.toggleAdvancedOptions()
+    cy.get('button').contains('Add another project').click();
+    cy.get('#additional_project_0').getByLabel('Additional project name')
+      .type('Password Policy')
+      .wait(100)
+      .type(' Pwned')
+      .wait(2000)
+      .type('{downArrow}{enter}')
+    cy.wait(400)
+
+    cy.get('button').contains('Launch sandbox').click()
+
+    cy.wait('@launch').its('request.body.additionalProjects').should(projects => {
+      expect(projects).to.have.length(1)
+      expect(projects[0]).to.not.have.property('id')
+      expect(projects[0].shortname).to.eq('password_policy_pwned')
+    })
+  })
 })

--- a/web/themes/simplytest_theme/lib/components/AdditionalProjects.jsx
+++ b/web/themes/simplytest_theme/lib/components/AdditionalProjects.jsx
@@ -4,6 +4,12 @@ import ProjectSelection from "./ProjectSelection";
 import Patches from "./Patches";
 import { btnDashed, removeButton } from "../ui";
 
+let rowIdCounter = 0;
+function nextRowId() {
+  rowIdCounter += 1;
+  return `additional-project-${rowIdCounter}`;
+}
+
 function AdditionalProjects() {
   const {
     additionalProjects,
@@ -17,6 +23,10 @@ function AdditionalProjects() {
     setAdditionalProjects([
       ...additionalProjects,
       {
+        // A row needs a key before it has a shortname, and two empty rows
+        // would otherwise both key on "". The launcher strips this before
+        // the payload goes to the backend, which rejects unknown properties.
+        id: nextRowId(),
         title: "",
         shortname: "",
         version: "",
@@ -36,7 +46,7 @@ function AdditionalProjects() {
     <div className="flex w-full flex-col items-start gap-3">
       {additionalProjects.map((project, k) => (
         <div
-          key={project.shortname}
+          key={project.id}
           id={`additional_project_${k}`}
           className="flex w-full flex-col gap-3 border-b border-st-hairline2 pb-4 last:border-0"
         >
@@ -68,11 +78,18 @@ function AdditionalProjects() {
                   // Copy the array. Mutating it in place and passing the
                   // same reference back makes React bail out of the render,
                   // so the patch field below never mounts. See #3571405.
+                  const previous = additionalProjects[k];
                   const newProjects = [...additionalProjects];
                   newProjects[k] = {
+                    ...changedProject,
+                    id: previous.id,
                     version: changedVersion,
-                    patches: [],
-                    ...changedProject
+                    // Only a different project invalidates the patches. A
+                    // version change keeps them, matching the root project.
+                    patches:
+                      previous.shortname === changedProject.shortname
+                        ? previous.patches
+                        : []
                   };
                   setAdditionalProjects(newProjects);
                 }

--- a/web/themes/simplytest_theme/lib/context/launcher.jsx
+++ b/web/themes/simplytest_theme/lib/context/launcher.jsx
@@ -72,7 +72,9 @@ export function LauncherProvider({ children }) {
       drupalVersion,
       installProfile,
       manualInstall,
-      additionalProjects,
+      // `id` only keys the rows in the UI. The backend builds typed data from
+      // this payload and throws on properties it does not define.
+      additionalProjects: additionalProjects.map(({ id, ...project }) => project),
     }
   }
 


### PR DESCRIPTION
The two follow-ups noted in #600, both in `AdditionalProjects.jsx`.

## Patches were discarded on a version change

`onChange` rebuilt the row with `patches: []`, and it fires on version changes as well as project changes. Type a patch URL for an additional project, change its version, and the URL is gone with no indication.

The root project does not behave this way: `setMainProject` never touches `patches`, so root patches survive a version change. Additional projects now match. Only picking a different project clears them.

Moving `version` and `patches` after the `...changedProject` spread also fixes a latent override: a stray `version` key on the project object used to win over the `changedVersion` argument.

## Rows shared a key

`key={project.shortname}` is `""` until a project is picked, so adding two rows before filling either gave both the same key. Each row now gets an id when it is created.

That id is a UI concern and must not reach the wire. `validateSubmission` builds typed data from the payload, and an unknown property on the Map throws, which the controller turns into a 503. So `getLaunchPayload` strips it.

## Testing

Three tests added, and I want to be precise about what each one is worth:

- **Patches survive a version change** — a real regression test. Verified failing before the fix, passing after.
- **Two rows render separately** — passes with and without the fix. React tolerates the duplicate key here because the row ids come from the map index, so there is no visible failure to reproduce. It guards the arrangement, it does not prove a bug was fixed. The key change stands on React requiring unique keys, not on this test.
- **Row id absent from the launch payload** — guards the strip in `getLaunchPayload`. It cannot fail against the old code, which had no id at all.

All five tests in the spec pass locally against ddev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)