### PR TITLE
Describe the patch URL format below the field (#3494635)

### DIFF
--- a/cypress/e2e/additional_projects.cy.js
+++ b/cypress/e2e/additional_projects.cy.js
@@ -78,6 +78,32 @@ describe('Tests additional projects and version constraints', () => {
     cy.get('#additional_project_0 input[type=url]').should('have.value', patchUrl)
   })
 
+  // #3494635: the format hint is rendered once per Patches instance, so the
+  // root project and each additional project must not share an id.
+  it('should give each patch field its own format hint', function () {
+    cy.pickProject('Password Policy')
+    cy.toggleAdvancedOptions()
+    cy.get('button').contains('Add another project').click();
+    cy.get('#additional_project_0').getByLabel('Additional project name')
+      .type('Password Policy')
+      .wait(100)
+      .type(' Pwned')
+      .wait(2000)
+      .type('{downArrow}{enter}')
+    cy.wait(400)
+
+    cy.get('input[type=url]').then(($inputs) => {
+      const hintIds = [...$inputs].map((input) =>
+        input.getAttribute('aria-describedby')
+      )
+      expect(hintIds).to.have.length(2)
+      expect(new Set(hintIds).size, 'distinct hint ids').to.eq(2)
+      hintIds.forEach((hintId) => {
+        cy.get(`[id="${hintId}"]`).should('have.length', 1).and('be.visible')
+      })
+    })
+  })
+
   // Rows used to key on the shortname, which is "" until a project is picked,
   // so two empty rows shared a key. React tolerates that here because the row
   // ids come from the map index, so this does not reproduce a visible failure.

--- a/cypress/e2e/launch_form.cy.js
+++ b/cypress/e2e/launch_form.cy.js
@@ -49,6 +49,24 @@ describe('Test the launch form', function () {
     cy.get('#project_patch_1').get('button').contains('×').click();
     cy.get('#project_patch_0').get('button').contains('×').click();
   })
+  // #3494635: the placeholder was the only hint about the expected format, and
+  // it disappears the moment you type. The description below the field does not.
+  it('should keep the patch format hint visible while typing', function () {
+    cy.pickProject('Pathauto')
+    cy.toggleAdvancedOptions()
+    cy.getByLabel('Project patch 0')
+      .type('https://www.drupal.org/files/issues/2020-12-07/3185080-3.patch')
+
+    // useId() puts colons in the id, so this cannot be a `#id` selector.
+    cy.getByLabel('Project patch 0')
+      .invoke('attr', 'aria-describedby')
+      .then((hintId) => {
+        expect(hintId, 'the patch field describes itself').to.be.a('string')
+        cy.get(`[id="${hintId}"]`)
+          .should('be.visible')
+          .and('contain', 'https://www.drupal.org/files/')
+      })
+  })
   it('should adjust available core versions based on compatibility', function () {
     cy.pickProject('Pathauto')
     cy.getByLabel('Version')

--- a/web/themes/simplytest_theme/lib/components/Patches.jsx
+++ b/web/themes/simplytest_theme/lib/components/Patches.jsx
@@ -1,10 +1,15 @@
-import React from "react";
+import React, { useId } from "react";
 import PropTypes from "prop-types";
 import { btnDashed, removeButton } from "../ui";
 
 // NOTE: We receive patches and setPatches as props, since this component is
 // shared between the root project and any additional projects.
 function Patches({ patches, setPatches }) {
+  // The launch form renders this component once for the root project and again
+  // for every additional project, so the hint below the fields needs an id that
+  // is unique per instance before aria-describedby can point at it.
+  const hintId = `${useId()}patch-hint`;
+
   if (patches.length === 0) {
     patches.push("");
   }
@@ -42,6 +47,7 @@ function Patches({ patches, setPatches }) {
             }}
             className="min-w-0 flex-1 rounded-lg border border-st-field-line bg-white px-3.5 py-3 font-mono text-[13px] text-st-body"
             placeholder="https://www.drupal.org/files/..."
+            aria-describedby={hintId}
           />
           <button
             className={removeButton}
@@ -53,6 +59,17 @@ function Patches({ patches, setPatches }) {
           </button>
         </div>
       ))}
+      {/* The placeholder vanishes as soon as someone types, taking the only
+          hint about the expected format with it. See #3494635. */}
+      <p
+        id={hintId}
+        className="m-0 w-full break-words text-[13px] leading-normal text-st-muted"
+      >
+        Paste the full URL of a patch file, like{" "}
+        <span className="font-mono">
+          https://www.drupal.org/files/issues/3494635-12.patch
+        </span>
+      </p>
       <button type="button" className={btnDashed} onClick={addPatch}>
         + Add another patch
       </button>


### PR DESCRIPTION
## What

The patch URL field now has a visible description under it — "Paste the full URL of a patch file, like `https://www.drupal.org/files/issues/3494635-12.patch`" — instead of relying on the placeholder alone.

## Why

[#3494635](https://www.drupal.org/project/simplytest/issues/3494635): the placeholder was the only thing telling you what a valid value looks like, and every browser clears it as soon as you type. Once the field had content there was no way back to that hint without emptying it.

The issue floated a floating-label animation, with the `prefers-reduced-motion` handling that implies. The thread settled on the simpler option instead — a plain description below the field, which is what this does. No animation, no motion query.

## How

`Patches.jsx` renders once for the root project and again for every additional project, so a hardcoded id on the description would repeat across the page and `aria-describedby` would resolve to whichever came first. The hint id comes from `useId()` so each instance gets its own, and every input in that group points at it.

The description uses `text-st-muted` rather than the `text-st-soft` the neighboring panel copy uses. `st-soft` (#7c8b9a) is 3.5:1 on white and misses WCAG AA for normal text; `st-muted` (#5a6b7c) is 5.5:1. Not fixing the existing uses here, but not adding another one to an accessibility fix either.

The placeholder stays, since it still reads well on an empty field and the description now covers the case where it disappears.

## Testing

Three Cypress specs, all run locally against ddev:

- `launch_form.cy.js` — the hint stays visible and keeps its content after typing a URL into the field.
- `additional_projects.cy.js` — a root project and an additional project produce two distinct hint ids, each resolving to exactly one visible element.
- Existing patch and additional-project tests still pass (12 total across both specs).

Screenshot of the filled field with the hint below it is in the issue.

## Not in this PR

Two pre-existing warts in the same component, both worth a follow-up:

- The input ids (`project_patch_url_0`) and row ids (`project_patch_0`) are hardcoded, so they collide between the root project and each additional project. The additional project's `sr-only` label points `for` at the root project's input.
- The `sr-only` label and remove button read "Project patch 0" / "Remove patch 0" — zero-indexed, so the first field announces as 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)