### PR TITLE
Fix duplicate ids and zero-indexed labels on the patch fields

### DIFF
--- a/cypress/e2e/additional_projects.cy.js
+++ b/cypress/e2e/additional_projects.cy.js
@@ -78,6 +78,32 @@ describe('Tests additional projects and version constraints', () => {
     cy.get('#additional_project_0 input[type=url]').should('have.value', patchUrl)
   })
 
+  // The patch field ids were hardcoded, so the root project and every
+  // additional project all rendered project_patch_url_0. The additional
+  // project's sr-only label pointed `for` at the root project's input.
+  it('should give every patch field a unique id its own label points at', function () {
+    cy.pickProject('Password Policy')
+    cy.toggleAdvancedOptions()
+    cy.get('button').contains('Add another project').click();
+    cy.get('#additional_project_0').getByLabel('Additional project name')
+      .type('Password Policy')
+      .wait(100)
+      .type(' Pwned')
+      .wait(2000)
+      .type('{downArrow}{enter}')
+    cy.wait(400)
+
+    cy.get('input[type=url]').then(($inputs) => {
+      const ids = [...$inputs].map((input) => input.id)
+      expect(ids, 'every patch input has an id').to.have.length(2).and.to.not.include('')
+      expect(new Set(ids).size, 'distinct patch input ids').to.eq(2)
+      ids.forEach((id) => {
+        cy.get(`[id="${id}"]`).should('have.length', 1)
+        cy.get(`label[for="${id}"]`).should('have.length', 1)
+      })
+    })
+  })
+
   // #3494635: the format hint is rendered once per Patches instance, so the
   // root project and each additional project must not share an id.
   it('should give each patch field its own format hint', function () {

--- a/cypress/e2e/launch_form.cy.js
+++ b/cypress/e2e/launch_form.cy.js
@@ -41,24 +41,28 @@ describe('Test the launch form', function () {
   it('should allow me to attach a patch to my project', function () {
     cy.pickProject('Pathauto')
     cy.toggleAdvancedOptions()
-    cy.getByLabel('Project patch 0')
+    cy.getByLabel('Project patch 1')
       .type('https://www.drupal.org/files/issues/2020-12-07/3185080-3.patch')
     cy.wait(200);
     cy.get('button').contains('Add another patch').click();
-    cy.getByLabel('Project patch 1');
-    cy.get('#project_patch_1').get('button').contains('×').click();
-    cy.get('#project_patch_0').get('button').contains('×').click();
+    cy.getByLabel('Project patch 2');
+    // Select the remove buttons by accessible name. `cy.get()` always queries
+    // from the document root, so the old `cy.get('#project_patch_1').get(...)`
+    // was not scoped to that row and clicked the first × on the page twice.
+    cy.get('button[aria-label="Remove patch 2"]').click();
+    cy.get('button[aria-label="Remove patch 1"]').click();
+    cy.get('input[type=url]').should('have.length', 1);
   })
   // #3494635: the placeholder was the only hint about the expected format, and
   // it disappears the moment you type. The description below the field does not.
   it('should keep the patch format hint visible while typing', function () {
     cy.pickProject('Pathauto')
     cy.toggleAdvancedOptions()
-    cy.getByLabel('Project patch 0')
+    cy.getByLabel('Project patch 1')
       .type('https://www.drupal.org/files/issues/2020-12-07/3185080-3.patch')
 
-    // useId() puts colons in the id, so this cannot be a `#id` selector.
-    cy.getByLabel('Project patch 0')
+    // Read the id off the field rather than hardcoding the hint's id here.
+    cy.getByLabel('Project patch 1')
       .invoke('attr', 'aria-describedby')
       .then((hintId) => {
         expect(hintId, 'the patch field describes itself').to.be.a('string')

--- a/cypress/e2e/launch_form_prefill.cy.js
+++ b/cypress/e2e/launch_form_prefill.cy.js
@@ -15,7 +15,7 @@ describe('Autofil of launch form from query parameters', function () {
       .should('have.value', 'Drupal core')
     cy.getByLabel('Version')
       .should('have.value', '9.3.x-dev')
-    cy.getByLabel('Project patch 0')
+    cy.getByLabel('Project patch 1')
       .should('have.value', 'https://www.drupal.org/files/issues/2021-05-16/3214191-2.patch')
   })
 

--- a/web/themes/simplytest_theme/lib/components/AdditionalProjects.jsx
+++ b/web/themes/simplytest_theme/lib/components/AdditionalProjects.jsx
@@ -106,6 +106,7 @@ function AdditionalProjects() {
           </div>
           {project.shortname ? (
             <Patches
+              idPrefix={`additional_project_${k}_patch`}
               patches={project.patches}
               setPatches={updatedPatches => {
                 const newProjects = [...additionalProjects];

--- a/web/themes/simplytest_theme/lib/components/AdditionalProjects.jsx
+++ b/web/themes/simplytest_theme/lib/components/AdditionalProjects.jsx
@@ -98,7 +98,7 @@ function AdditionalProjects() {
             <button
               className={removeButton}
               type="button"
-              aria-label={`Remove additional project ${k}`}
+              aria-label={`Remove additional project ${k + 1}`}
               onClick={() => removeExtraProject(k)}
             >
               <span aria-hidden="true">×</span>

--- a/web/themes/simplytest_theme/lib/components/AdvancedOptions.jsx
+++ b/web/themes/simplytest_theme/lib/components/AdvancedOptions.jsx
@@ -79,7 +79,11 @@ function AdvancedOptions() {
             title="Patches"
             description="Apply patch files from drupal.org issues before the site is built."
           >
-            <Patches patches={patches} setPatches={setPatches} />
+            <Patches
+              patches={patches}
+              setPatches={setPatches}
+              idPrefix="project_patch"
+            />
           </OptionGroup>
 
           <OptionGroup

--- a/web/themes/simplytest_theme/lib/components/Patches.jsx
+++ b/web/themes/simplytest_theme/lib/components/Patches.jsx
@@ -35,7 +35,7 @@ function Patches({ patches, setPatches, idPrefix }) {
         // eslint-disable-next-line react/no-array-index-key
         <div key={k} id={`${idPrefix}_${k}`} className="flex w-full flex-row gap-2.5">
           <label className="sr-only" htmlFor={`${idPrefix}_url_${k}`}>
-            Project patch {k}
+            Project patch {k + 1}
           </label>
           <input
             id={`${idPrefix}_url_${k}`}
@@ -53,7 +53,7 @@ function Patches({ patches, setPatches, idPrefix }) {
           <button
             className={removeButton}
             type="button"
-            aria-label={`Remove patch ${k}`}
+            aria-label={`Remove patch ${k + 1}`}
             onClick={() => removeExtraPatch(k)}
           >
             <span aria-hidden="true">×</span>

--- a/web/themes/simplytest_theme/lib/components/Patches.jsx
+++ b/web/themes/simplytest_theme/lib/components/Patches.jsx
@@ -1,14 +1,15 @@
-import React, { useId } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { btnDashed, removeButton } from "../ui";
 
 // NOTE: We receive patches and setPatches as props, since this component is
 // shared between the root project and any additional projects.
-function Patches({ patches, setPatches }) {
+function Patches({ patches, setPatches, idPrefix }) {
   // The launch form renders this component once for the root project and again
-  // for every additional project, so the hint below the fields needs an id that
-  // is unique per instance before aria-describedby can point at it.
-  const hintId = `${useId()}patch-hint`;
+  // for every additional project. Every id below is built from idPrefix so the
+  // instances do not collide: shared ids sent each additional project's label
+  // and aria-describedby to the root project's field instead of its own.
+  const hintId = `${idPrefix}_hint`;
 
   if (patches.length === 0) {
     patches.push("");
@@ -32,12 +33,12 @@ function Patches({ patches, setPatches }) {
         // peformance problem as we're constantly rebuilding the entire component
         // whenever someone types.
         // eslint-disable-next-line react/no-array-index-key
-        <div key={k} id={`project_patch_${k}`} className="flex w-full flex-row gap-2.5">
-          <label className="sr-only" htmlFor={`project_patch_url_${k}`}>
+        <div key={k} id={`${idPrefix}_${k}`} className="flex w-full flex-row gap-2.5">
+          <label className="sr-only" htmlFor={`${idPrefix}_url_${k}`}>
             Project patch {k}
           </label>
           <input
-            id={`project_patch_url_${k}`}
+            id={`${idPrefix}_url_${k}`}
             type="url"
             value={patch}
             onChange={event => {
@@ -78,6 +79,9 @@ function Patches({ patches, setPatches }) {
 }
 Patches.propTypes = {
   patches: PropTypes.arrayOf(PropTypes.string).isRequired,
-  setPatches: PropTypes.func.isRequired
+  setPatches: PropTypes.func.isRequired,
+  // Must be unique across the page. There is no default on purpose: a shared
+  // fallback is exactly the collision this prop exists to prevent.
+  idPrefix: PropTypes.string.isRequired
 };
 export default Patches;


### PR DESCRIPTION
## What

Two accessibility cleanups in `Patches.jsx`, both noticed while fixing [#3494635](https://www.drupal.org/project/simplytest/issues/3494635) in #602 and deliberately left out of it. One commit each.

## Duplicate element ids

`Patches` renders once for the root project and again for every additional project, but its ids were hardcoded — every instance emitted `project_patch_url_0`, `project_patch_0`, and so on.

Duplicate ids are invalid HTML, and the practical effect was real: an additional project's `sr-only` label pointed `for` at the *root* project's input, so activating it focused the wrong field. `aria-describedby` on the new format hint had the same problem.

Every id is now built from a required `idPrefix` prop the call site supplies — `project_patch` for the root, `additional_project_{k}_patch` for each extra row. No default value, since a shared fallback is exactly the collision the prop exists to prevent.

I used an explicit prop rather than `useId()` (which #602 used for the hint id) so the ids stay readable in the DOM and usable as plain CSS selectors — `useId()` emits colons, which would have forced every `#id` selector in the Cypress suite through the shared `getByLabel` helper to change.

## Zero-indexed accessible names

The `sr-only` label and the remove button counted from the array index, so a screen reader announced the first patch field as "Project patch 0" and its remove button as "Remove patch 0". Additional project rows had the same thing in "Remove additional project 0".

The visible text now counts from one. Element ids stay index-based, matching the array they come from.

## Drive-by in the tests

`cy.get()` always queries from the document root — it does not scope to the previous subject the way `.find()` does. So `cy.get('#project_patch_1').get('button').contains('×').click()` was never scoped to that row and clicked the first × on the page twice. The remove-button assertions now select on accessible name, which is the thing this PR changes anyway, and the test asserts the field count afterward.

## Testing

Full Cypress suite run locally against ddev — 19 tests across all 5 specs, all passing.

New in `additional_projects.cy.js`: with a root project and an additional project on the page, every patch input has a non-empty id, the ids are distinct, and each one resolves to exactly one element with exactly one label pointing at it.

I verified the guard works by temporarily giving `AdditionalProjects` the root's `idPrefix`. The new test and the format-hint test from #602 both fail; everything else still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)