### PR TITLE
Ignore the empty patch row the launch form always submits

### DIFF
--- a/web/modules/custom/simplytest_tugboat/src/PreviewConfigGenerator.php
+++ b/web/modules/custom/simplytest_tugboat/src/PreviewConfigGenerator.php
@@ -330,16 +330,44 @@ final readonly class PreviewConfigGenerator {
   private function getPatchesFile(array $parameters): string {
     $patches = [];
     $package = 'drupal/' . $parameters['project'];
-    foreach ($parameters['patches'] as $patch) {
+    foreach ($this->getSubmittedPatches($parameters['patches']) as $patch) {
       $patches[$package][] = $this->buildPatchDefinition($package, $patch);
     }
     foreach ($parameters['additionals'] as $additional) {
-      foreach ($additional['patches'] as $additional_patch) {
-        $package = 'drupal/' . $additional['shortname'];
+      $package = 'drupal/' . $additional['shortname'];
+      foreach ($this->getSubmittedPatches($additional['patches']) as $additional_patch) {
         $patches[$package][] = $this->buildPatchDefinition($package, $additional_patch);
       }
     }
     return json_encode(['patches' => $patches], JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+  }
+
+  /**
+   * Returns the patch URLs a project was actually given.
+   *
+   * The launch form renders a patch field for every project whether or not it
+   * is used, so a submission carries an empty string for each project left
+   * unpatched. Those must not reach the build: composer-patches takes an empty
+   * URL at face value and fails the whole update with "$url must not be an
+   * empty string".
+   *
+   * @param array<mixed> $patches
+   *   The submitted patch values for one project.
+   *
+   * @return list<string>
+   *   The patch URLs to apply.
+   *
+   * @see https://www.drupal.org/project/simplytest/issues/3348026
+   */
+  private function getSubmittedPatches(array $patches): array {
+    $urls = [];
+    foreach ($patches as $patch) {
+      $patch = trim((string) $patch);
+      if ($patch !== '') {
+        $urls[] = $patch;
+      }
+    }
+    return $urls;
   }
 
   /**
@@ -398,11 +426,11 @@ final readonly class PreviewConfigGenerator {
    *   TRUE if the project or any additional project has a patch.
    */
   private function hasPatches(array $parameters): bool {
-    if (!empty($parameters['patches'])) {
+    if ($this->getSubmittedPatches($parameters['patches']) !== []) {
       return TRUE;
     }
     foreach ($parameters['additionals'] as $additional) {
-      if (!empty($additional['patches'])) {
+      if ($this->getSubmittedPatches($additional['patches']) !== []) {
         return TRUE;
       }
     }
@@ -424,11 +452,11 @@ final readonly class PreviewConfigGenerator {
     if ($parameters['perform_install'] === FALSE) {
       $commands[] = $this->getLegacyPatchCommand(ProjectTypes::CORE, '', 'https://www.drupal.org/files/issues/2019-12-19/3077423-11.patch');
     }
-    foreach ($parameters['patches'] as $patch) {
+    foreach ($this->getSubmittedPatches($parameters['patches']) as $patch) {
       $commands[] = $this->getLegacyPatchCommand($parameters['project_type'], $parameters['project'], $patch);
     }
     foreach ($parameters['additionals'] as $additional) {
-      foreach ($additional['patches'] as $additional_patch) {
+      foreach ($this->getSubmittedPatches($additional['patches']) as $additional_patch) {
         $commands[] = $this->getLegacyPatchCommand($additional['type'], $additional['shortname'], $additional_patch);
       }
     }

--- a/web/modules/custom/simplytest_tugboat/tests/src/Unit/PatchesFileTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Unit/PatchesFileTest.php
@@ -143,6 +143,63 @@ final class PatchesFileTest extends UnitTestCase {
   }
 
   /**
+   * The empty patch row the form always submits is not a patch.
+   *
+   * Reproduces the report: a project plus two additional projects, none of them
+   * patched. composer-patches takes the empty URL at face value and fails the
+   * whole update with "$url must not be an empty string".
+   *
+   * @see https://www.drupal.org/project/simplytest/issues/3348026
+   */
+  public function testEmptyPatchRowsAreIgnored(): void {
+    $commands = $this->getBuildCommands([
+      'project' => 'antibot',
+      'patches' => [''],
+      'additionals' => [
+        ['shortname' => 'gin', 'version' => '8.x-3.0', 'patches' => ['']],
+        ['shortname' => 'gin_login', 'version' => '8.x-2.1', 'patches' => ['']],
+      ],
+    ]);
+
+    self::assertContains('cd stm && composer update --no-ansi', $commands);
+    self::assertSame([], array_filter(
+      $commands,
+      static fn (string $command): bool => str_contains($command, 'patches.json')
+    ));
+  }
+
+  /**
+   * An empty row alongside a real patch drops only the empty row.
+   */
+  public function testEmptyRowsAreDroppedFromRealPatches(): void {
+    $patches = $this->getPatchesFile([
+      'patches' => [''],
+      'additionals' => [
+        [
+          'shortname' => 'pathauto',
+          'version' => '8.x-1.8',
+          'patches' => ['', 'https://www.drupal.org/files/issues/one.patch', ''],
+        ],
+      ],
+    ]);
+
+    self::assertSame(['drupal/pathauto'], array_keys($patches));
+    self::assertCount(1, $patches['drupal/pathauto']);
+  }
+
+  /**
+   * A field holding only whitespace is empty.
+   */
+  public function testWhitespaceOnlyPatchIsIgnored(): void {
+    $commands = $this->getBuildCommands(['patches' => ['   ']]);
+
+    self::assertSame([], array_filter(
+      $commands,
+      static fn (string $command): bool => str_contains($command, 'patches.json')
+    ));
+  }
+
+  /**
    * A build without patches does not install the patcher or go verbose.
    */
   public function testBuildWithoutPatches(): void {


### PR DESCRIPTION
## What changed

A project left unpatched no longer contributes a patch entry to the build. Selecting additional projects without patching them works.

## Why

Reported in [#3348026](https://www.drupal.org/project/simplytest/issues/3348026), open since March 2023 with four people confirming it.

The launch form renders a patch field for every project whether or not it is used, and `getLaunchPayload()` posts those fields verbatim. Every project left unpatched therefore submits `""`, and the generator turned each one into a real patch entry.

Under the old `composer patch-add` build that failed with the message in the report:

```
In PatchAddCommand.php line 75:
  Your patch url argument must be a valid URL or local path.
```

Since #604 generates `patches.json` directly, it fails differently but just as hard:

```
In HttpDownloader.php line 154:
  [InvalidArgumentException]
  $url must not be an empty string
```

The documented workaround has been to paste a throwaway patch URL into every field, which is why comment #9 says they were "loath to clutter [other projects] with a blank merge request."

## How

`getSubmittedPatches()` drops empty and whitespace-only values. It is used by `getPatchesFile()`, `hasPatches()`, and the Drupal 7 path, where an empty value produced `curl '' | patch -p1`.

Filtering server-side rather than in the form covers every client: the JSON POST, `?patch=` prefill links, and one-click demos.

Because `hasPatches()` now agrees, a build whose only patch fields are empty installs no patcher and runs a plain `composer update` instead of `composer update -v`.

## Testing notes

`testEmptyPatchRowsAreIgnored` reproduces the report exactly: a project plus two additional projects, none patched, asserting no `patches.json` is written. Also covered: empty rows interleaved with a real patch, and whitespace-only input.

Verified against the shipped generator before the fix, which produced

```json
{"patches":{"drupal/antibot":[{"description":"STM patch ","url":"", ...}]}}
```

and after, which produces no patching commands at all. The `$url must not be an empty string` failure above was reproduced in `tugboatqa/php:apache`.

49 tests pass, PHPStan and Rector clean.

## Not included

The form's `Patches` component does `patches.push("")` during render, mutating a prop. That is why the "x" appears to do nothing on the last row, which the reporter noticed. Showing a field per project is deliberate (#600), and with this fix an unused field is harmless, so I left the component alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)