### PR TITLE
Derive the placeholder patch row instead of writing it into state

### DIFF
--- a/cypress/e2e/launch_form.cy.js
+++ b/cypress/e2e/launch_form.cy.js
@@ -53,6 +53,17 @@ describe('Test the launch form', function () {
     cy.get('button[aria-label="Remove patch 1"]').click();
     cy.get('input[type=url]').should('have.length', 1);
   })
+  // The test above types into the first field before adding a second, so it
+  // never covered adding one straight from the placeholder row. That row is
+  // derived rather than stored, which is the case most likely to break.
+  it('should add a second patch field before anything is typed', function () {
+    cy.pickProject('Pathauto')
+    cy.toggleAdvancedOptions()
+    cy.get('input[type=url]').should('have.length', 1);
+    cy.get('button').contains('Add another patch').click();
+    cy.getByLabel('Project patch 2');
+    cy.get('input[type=url]').should('have.length', 2);
+  })
   // #3494635: the placeholder was the only hint about the expected format, and
   // it disappears the moment you type. The description below the field does not.
   it('should keep the patch format hint visible while typing', function () {

--- a/web/themes/simplytest_theme/lib/components/Patches.jsx
+++ b/web/themes/simplytest_theme/lib/components/Patches.jsx
@@ -11,23 +11,29 @@ function Patches({ patches, setPatches, idPrefix }) {
   // and aria-describedby to the root project's field instead of its own.
   const hintId = `${idPrefix}_hint`;
 
-  if (patches.length === 0) {
-    patches.push("");
-  }
+  // A project holds no patches until someone types, but it always shows one
+  // field so it is there the moment the project is selected. See #3571405.
+  //
+  // Derive that row instead of pushing it into `patches`. The prop is the
+  // parent's own state array, so `patches.push("")` wrote into React state
+  // during render. It happened to behave, because every read afterwards saw
+  // the same mutated array, but it left the component relying on that and gave
+  // the parent a state value it never set.
+  const rows = patches.length === 0 ? [""] : patches;
 
   function addPatch() {
-    setPatches([...patches, '']);
+    setPatches([...rows, '']);
   }
 
   function removeExtraPatch(k) {
-    const patchesCopy = patches.slice();
+    const patchesCopy = rows.slice();
     patchesCopy.splice(k, 1);
     setPatches(patchesCopy);
   }
 
   return (
     <div className="flex w-full flex-col items-start gap-3">
-      {patches.map((patch, k) => (
+      {rows.map((patch, k) => (
         // NOTE: we should not use `k`, but if we use `patch`, the value is
         // constantly modified onChange as the array is rebuilt. This is a major
         // peformance problem as we're constantly rebuilding the entire component
@@ -42,7 +48,7 @@ function Patches({ patches, setPatches, idPrefix }) {
             type="url"
             value={patch}
             onChange={event => {
-              const newPatches = [...patches];
+              const newPatches = [...rows];
               newPatches[k] = event.target.value;
               setPatches(newPatches);
             }}


### PR DESCRIPTION
## What changed

`Patches` no longer mutates React state during render. No behaviour change.

## Why

A project with no patches still shows one empty field, so it is there the moment the project is selected (#3571405). That row was produced with:

```js
if (patches.length === 0) {
  patches.push("");
}
```

`patches` is the parent's own state array, so this wrote into React state during render. The parent ended up holding a value it never set, and the component depended on that aliasing for the rest of the render.

To be clear about the scope: this is not a user-visible bug. I expected "Add another patch" to no-op on the first click and wrote a Cypress test for it, but the test passes against the old code too. The push mutates the real state array, so every subsequent read sees `[""]` and the arithmetic works out. This is a correctness cleanup, not a fix.

## How

```js
const rows = patches.length === 0 ? [""] : patches;
```

`rows` is then used by the render, `addPatch`, `removeExtraPatch`, and the input's `onChange`. Every state transition is identical to before:

| Action, from state `[]` | Before | After |
|---|---|---|
| Add another patch | `["", ""]` | `["", ""]` |
| Type in row 0 | `[value]` | `[value]` |
| Remove row 0 | `[]`, renders one row | `[]`, renders one row |

## Testing notes

Both patch specs pass against a local ddev site, 14 tests total.

Added a Cypress case for adding a second field straight from the placeholder row. The existing test types into the first field before clicking add, so it never exercised the derived row. The new case passes with and without this change, so it is coverage rather than a regression test, and it locks in the behaviour now that the row is derived rather than stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)