### PR TITLE
Only launch known core releases and offered install profiles

### DIFF
--- a/web/modules/custom/simplytest_launch/src/Plugin/Validation/Constraint/CoreVersionConstraint.php
+++ b/web/modules/custom/simplytest_launch/src/Plugin/Validation/Constraint/CoreVersionConstraint.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\simplytest_launch\Plugin\Validation\Constraint;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Validation\Attribute\Constraint;
+use Symfony\Component\Validator\Constraint as SymfonyConstraint;
+
+/**
+ * Only known Drupal core releases may be launched.
+ *
+ * The launch form offers the releases stored by CoreVersionManager, but the
+ * launch endpoint accepts any JSON body. Whatever is submitted here ends up in
+ * the sandbox's Composer command and in the public launch statistics, so it has
+ * to be a release we actually know about.
+ */
+#[Constraint(
+  id: 'CoreVersion',
+  label: new TranslatableMarkup('Drupal core version', [], ['context' => 'Validation']),
+)]
+final class CoreVersionConstraint extends SymfonyConstraint {
+
+  public string $message = 'There is no Drupal core release with the version @version.';
+
+}

--- a/web/modules/custom/simplytest_launch/src/Plugin/Validation/Constraint/CoreVersionConstraintValidator.php
+++ b/web/modules/custom/simplytest_launch/src/Plugin/Validation/Constraint/CoreVersionConstraintValidator.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\simplytest_launch\Plugin\Validation\Constraint;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\simplytest_projects\CoreVersionManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+final class CoreVersionConstraintValidator extends ConstraintValidator implements ContainerInjectionInterface {
+
+  public function __construct(
+    private readonly CoreVersionManager $coreVersionManager,
+  ) {
+  }
+
+  #[\Override]
+  public static function create(ContainerInterface $container): self {
+    return new self($container->get('simplytest_projects.core_version_manager'));
+  }
+
+  #[\Override]
+  public function validate(mixed $value, Constraint $constraint): void {
+    assert($constraint instanceof CoreVersionConstraint);
+    $version = (string) $value;
+    // NotBlank already reports an empty value. One message is enough.
+    if ($version === '') {
+      return;
+    }
+    if (!$this->coreVersionManager->hasVersion($version)) {
+      $this->context->buildViolation($constraint->message)
+        ->setParameter('@version', $version)
+        ->addViolation();
+    }
+  }
+
+}

--- a/web/modules/custom/simplytest_launch/src/TypedData/InstanceLaunchDefinition.php
+++ b/web/modules/custom/simplytest_launch/src/TypedData/InstanceLaunchDefinition.php
@@ -10,6 +10,16 @@ use Drupal\Core\TypedData\ListDataDefinition;
 final class InstanceLaunchDefinition extends ComplexDataDefinitionBase {
 
   /**
+   * The install profiles a launch may ask for.
+   *
+   * These are the options the launch form offers, in
+   * web/themes/simplytest_theme/lib/components/InstallationOptions.jsx. The
+   * value is interpolated into the sandbox's `drush si` command and shown on
+   * the public launch statistics, so nothing else may get through.
+   */
+  public const array INSTALL_PROFILES = ['standard', 'minimal', 'demo_umami'];
+
+  /**
    * {@inheritdoc}
    */
   #[\Override]
@@ -26,14 +36,18 @@ final class InstanceLaunchDefinition extends ComplexDataDefinitionBase {
       ->addConstraint('ComplexData')
       ->setRequired(TRUE);
     $properties['drupalVersion'] = DataDefinition::create('string')
-      // @todo add a custom constraint validating a legit version.
       ->setLabel(new TranslatableMarkup('Drupal version'))
       ->addConstraint('NotBlank')
-      ->addConstraint('PrimitiveType');
+      ->addConstraint('PrimitiveType')
+      ->addConstraint('CoreVersion');
     $properties['installProfile'] = DataDefinition::create('string')
       ->setLabel(new TranslatableMarkup('Install profile'))
-      ->addConstraint('NotBlank')
       ->addConstraint('PrimitiveType')
+      // Rejects a blank value as well, so NotBlank would only repeat it.
+      ->addConstraint('Choice', [
+        'choices' => self::INSTALL_PROFILES,
+        'message' => 'The install profile must be one of ' . implode(', ', self::INSTALL_PROFILES) . '.',
+      ])
       ->setRequired(TRUE);
     $properties['manualInstall'] = DataDefinition::create('boolean')
       ->setLabel(new TranslatableMarkup('Manual installation'))

--- a/web/modules/custom/simplytest_launch/tests/src/Kernel/LaunchControllerTest.php
+++ b/web/modules/custom/simplytest_launch/tests/src/Kernel/LaunchControllerTest.php
@@ -45,6 +45,19 @@ final class LaunchControllerTest extends KernelTestBase {
     $this->config('tugboat.settings')
       ->set('repository_id', 'kerneltestrepo')
       ->save();
+
+    // The core release every launch below asks for.
+    $this->container->get('database')->insert(CoreVersionManager::TABLE_NAME)
+      ->fields([
+        'version' => '9.3.2',
+        'major' => 9,
+        'minor' => 3,
+        'patch' => 2,
+        'extra' => '',
+        'vcs_label' => '9.3.2',
+        'insecure' => 0,
+      ])
+      ->execute();
   }
 
   /**
@@ -160,7 +173,7 @@ final class LaunchControllerTest extends KernelTestBase {
         'version' => '8.x-1.9',
       ],
       'drupalVersion' => '9.3.2',
-      'installProfile' => 'umami',
+      'installProfile' => 'demo_umami',
       'manualInstall' => '0',
     ]));
 
@@ -209,12 +222,69 @@ final class LaunchControllerTest extends KernelTestBase {
         'version' => '8.x-99.0',
       ],
       'drupalVersion' => '9.3.2',
-      'installProfile' => 'umami',
+      'installProfile' => 'demo_umami',
       'manualInstall' => '0',
     ]));
 
     self::assertEquals(422, $response->getStatusCode());
     self::assertStringContainsString('8.x-99.0', (string) $response->getContent());
+  }
+
+  /**
+   * Only a known core release may be launched.
+   *
+   * The form only offers stored releases, but the endpoint takes any JSON, and
+   * the value would otherwise reach the sandbox build and the public
+   * statistics untouched.
+   *
+   * @covers ::launchProject
+   * @covers \Drupal\simplytest_launch\Plugin\Validation\Constraint\CoreVersionConstraintValidator::validate
+   */
+  public function testLaunchProjectWithUnknownCoreVersion(): void {
+    $response = $this->handle($this->launchRequest([
+      'project' => [
+        'shortname' => 'token',
+        'type' => 'module',
+        'sandbox' => FALSE,
+        'version' => '8.x-1.9',
+      ],
+      'drupalVersion' => 'not a real core version',
+      'installProfile' => 'standard',
+      'manualInstall' => '0',
+    ]));
+
+    self::assertEquals(422, $response->getStatusCode());
+    $data = Json::decode((string) $response->getContent());
+    self::assertContains(
+      'drupalVersion: There is no Drupal core release with the version not a real core version.',
+      $data['errors']
+    );
+  }
+
+  /**
+   * Only the install profiles the form offers may be launched.
+   *
+   * @covers ::launchProject
+   */
+  public function testLaunchProjectWithUnknownInstallProfile(): void {
+    $response = $this->handle($this->launchRequest([
+      'project' => [
+        'shortname' => 'token',
+        'type' => 'module',
+        'sandbox' => FALSE,
+        'version' => '8.x-1.9',
+      ],
+      'drupalVersion' => '9.3.2',
+      'installProfile' => 'buy pills at example dot com',
+      'manualInstall' => '0',
+    ]));
+
+    self::assertEquals(422, $response->getStatusCode());
+    $data = Json::decode((string) $response->getContent());
+    self::assertContains(
+      'installProfile: The install profile must be one of standard, minimal, demo_umami.',
+      $data['errors']
+    );
   }
 
   /**
@@ -244,7 +314,7 @@ final class LaunchControllerTest extends KernelTestBase {
         'version' => '8.x-1.9',
       ],
       'drupalVersion' => '9.3.2',
-      'installProfile' => 'umami',
+      'installProfile' => 'demo_umami',
       'manualInstall' => '0',
     ]));
   }

--- a/web/modules/custom/simplytest_launch/tests/src/Kernel/TypedData/InstanceLaunchDefinitionTest.php
+++ b/web/modules/custom/simplytest_launch/tests/src/Kernel/TypedData/InstanceLaunchDefinitionTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\simplytest_launch\Kernel\TypedData;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_launch\Plugin\DataType\InstanceLaunch;
 use Drupal\simplytest_launch\TypedData\InstanceLaunchDefinition;
+use Drupal\simplytest_projects\CoreVersionManager;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 
 /**
@@ -27,6 +28,19 @@ final class InstanceLaunchDefinitionTest extends KernelTestBase {
   protected function setUp(): void {
     parent::setUp();
     $this->installConfig(['simplytest_launch']);
+    $this->installSchema('simplytest_projects', CoreVersionManager::TABLE_NAME);
+    // The one core release the valid submissions below ask for.
+    $this->container->get('database')->insert(CoreVersionManager::TABLE_NAME)
+      ->fields([
+        'version' => '9.1.0',
+        'major' => 9,
+        'minor' => 1,
+        'patch' => 0,
+        'extra' => '',
+        'vcs_label' => '9.1.0',
+        'insecure' => 0,
+      ])
+      ->execute();
   }
 
   /**
@@ -57,7 +71,25 @@ final class InstanceLaunchDefinitionTest extends KernelTestBase {
         0 => 'project.shortname: This value should not be blank.',
         1 => 'project.version: This value should not be blank.',
         2 => 'drupalVersion: This value should not be blank.',
-        3 => 'installProfile: This value should not be blank.',
+        3 => 'installProfile: The install profile must be one of standard, minimal, demo_umami.',
+      ]
+    ];
+    // Anything the form would not offer is rejected, however well formed.
+    yield [
+      [
+        'project' => [
+          'shortname' => 'token',
+          'type' => 'module',
+          'sandbox' => false,
+          'version' => '8.x-1.9',
+        ],
+        'drupalVersion' => '9.99.0',
+        'installProfile' => 'umami',
+        'manualInstall' => '0',
+      ],
+      [
+        0 => 'drupalVersion: There is no Drupal core release with the version 9.99.0.',
+        1 => 'installProfile: The install profile must be one of standard, minimal, demo_umami.',
       ]
     ];
     yield [
@@ -69,7 +101,7 @@ final class InstanceLaunchDefinitionTest extends KernelTestBase {
           'version' => '8.x-1.9',
         ],
         'drupalVersion' => '9.1.0',
-        'installProfile' => 'umami',
+        'installProfile' => 'demo_umami',
         'manualInstall' => '0',
       ],
       []
@@ -83,7 +115,7 @@ final class InstanceLaunchDefinitionTest extends KernelTestBase {
           'version' => '8.x-1.9',
         ],
         'drupalVersion' => '9.1.0',
-        'installProfile' => 'umami',
+        'installProfile' => 'demo_umami',
         'manualInstall' => '0',
       ],
       [
@@ -99,7 +131,7 @@ final class InstanceLaunchDefinitionTest extends KernelTestBase {
           'version' => '8.x-1.9',
         ],
         'drupalVersion' => '9.1.0',
-        'installProfile' => 'umami',
+        'installProfile' => 'demo_umami',
         'manualInstall' => '0',
         'additionalProjects' => [
           [
@@ -123,7 +155,7 @@ final class InstanceLaunchDefinitionTest extends KernelTestBase {
           ],
         ],
         'drupalVersion' => '9.1.0',
-        'installProfile' => 'umami',
+        'installProfile' => 'demo_umami',
         'manualInstall' => '0',
       ],
       [
@@ -143,7 +175,7 @@ final class InstanceLaunchDefinitionTest extends KernelTestBase {
           ],
         ],
         'drupalVersion' => '9.1.0',
-        'installProfile' => 'umami',
+        'installProfile' => 'demo_umami',
         'manualInstall' => '0',
       ],
       [
@@ -164,7 +196,7 @@ final class InstanceLaunchDefinitionTest extends KernelTestBase {
           ],
         ],
         'drupalVersion' => '9.1.0',
-        'installProfile' => 'umami',
+        'installProfile' => 'demo_umami',
         'manualInstall' => '0',
       ],
       [
@@ -184,7 +216,7 @@ final class InstanceLaunchDefinitionTest extends KernelTestBase {
           ],
         ],
         'drupalVersion' => '9.1.0',
-        'installProfile' => 'umami',
+        'installProfile' => 'demo_umami',
         'manualInstall' => '0',
       ],
       []

--- a/web/modules/custom/simplytest_projects/src/CoreVersionManager.php
+++ b/web/modules/custom/simplytest_projects/src/CoreVersionManager.php
@@ -57,6 +57,19 @@ final readonly class CoreVersionManager {
   }
 
   /**
+   * Whether a release is one we know about.
+   *
+   * @param string $version
+   *   The release, as the launch form submits it.
+   */
+  public function hasVersion(string $version): bool {
+    $query = $this->database->select(self::TABLE_NAME);
+    $query->addField(self::TABLE_NAME, 'version');
+    $query->condition('version', $version);
+    return $query->countQuery()->execute()->fetchField() > 0;
+  }
+
+  /**
    * Gets core versions satisfying a core compatibility constraint.
    *
    * @return array

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/CoreVersionManagerTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/CoreVersionManagerTest.php
@@ -90,6 +90,19 @@ final class CoreVersionManagerTest extends KernelTestBase {
   }
 
   /**
+   * @covers ::hasVersion
+   */
+  public function testHasVersion(): void {
+    self::assertFalse($this->sut->hasVersion('11.2.3'));
+
+    $this->sut->updateData(11);
+
+    self::assertTrue($this->sut->hasVersion('11.2.3'));
+    self::assertFalse($this->sut->hasVersion('11.2'));
+    self::assertFalse($this->sut->hasVersion('not a release'));
+  }
+
+  /**
    * @dataProvider coreVersionData
    * @covers ::updateData
    * @covers ::getVersions


### PR DESCRIPTION
The launch endpoint accepted any non-blank string for `drupalVersion` and `installProfile`. The form only ever sends releases from the core versions table and one of three install profiles, but the endpoint is an anonymous JSON POST and the form is not its only possible client.

That mattered more than it looked. Tugboat accepts a preview before the installer runs, so a made-up install profile still produced a "successful" launch, and the value is interpolated straight into the sandbox's `drush si` command. It also surfaced while reviewing #607, where anything submitted would have been shown on the public statistics page.

## What changed

- `installProfile` is limited to `standard`, `minimal` and `demo_umami`, the options in `InstallationOptions.jsx`. The list is a constant on `InstanceLaunchDefinition` with a pointer at the component that has to stay in sync. `NotBlank` came off this property because the choice constraint already rejects an empty value, and keeping both produced two messages for one mistake.
- `drupalVersion` gets a new `CoreVersion` constraint. Its validator asks `CoreVersionManager::hasVersion()` whether the release exists in the core versions table, which is the same table the form's dropdown reads. It stays quiet on a blank value so `NotBlank` remains the only message there.
- The constraint uses core's attribute-based discovery rather than the annotation the older patches constraint uses.

## Testing

- Two new 422 cases in `LaunchControllerTest`, one per constraint, and a definition-level data set that submits a well-formed but unknown version and profile together.
- `CoreVersionManagerTest` covers the new lookup.
- Existing fixtures that submitted `umami`, a value the form never sends, now submit `demo_umami`.
- PHPStan and Rector clean. Coverage holds above the gate.

#607 is stacked on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
