### PR TITLE
Invalidate the launch statistics report when a launch is recorded

### DIFF
--- a/web/modules/custom/simplytest_tugboat/simplytest_tugboat.services.yml
+++ b/web/modules/custom/simplytest_tugboat/simplytest_tugboat.services.yml
@@ -20,6 +20,7 @@ services:
       - '@database'
       - '@datetime.time'
       - '@logger.channel.simplytest_tugboat'
+      - '@cache_tags.invalidator'
   simplytest_tugboat.launch_statistics:
     class: Drupal\simplytest_tugboat\LaunchStatistics
     arguments:

--- a/web/modules/custom/simplytest_tugboat/src/Controller/LaunchStatisticsController.php
+++ b/web/modules/custom/simplytest_tugboat/src/Controller/LaunchStatisticsController.php
@@ -4,6 +4,7 @@ namespace Drupal\simplytest_tugboat\Controller;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\simplytest_tugboat\LaunchRecorder;
 use Drupal\simplytest_tugboat\LaunchStatistics;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -20,11 +21,11 @@ final readonly class LaunchStatisticsController implements ContainerInjectionInt
   private const int WINDOW_DAYS = 30;
 
   /**
-   * How long a rendered report stays fresh, in seconds.
+   * How long a rendered report stays fresh without a launch, in seconds.
    *
-   * The report is cached by time rather than by tag: tagging it would mean
-   * every launch invalidated the page, and nobody needs these numbers to be
-   * live. A day is plenty.
+   * A launch invalidates the report through its cache tag. The lifetime is
+   * for the days nobody launches anything: the breakdowns are a rolling
+   * window, so the page still has to roll over at midnight.
    *
    * This drives Drupal's own caches only. The browser and Fastly lifetimes
    * come from the site-wide Cache-Control headers like every other page.
@@ -76,6 +77,7 @@ final readonly class LaunchStatisticsController implements ContainerInjectionInt
         'first_recorded_at' => $this->statistics->getFirstRecordedAt(),
       ],
       '#cache' => [
+        'tags' => [LaunchRecorder::CACHE_TAG],
         'max-age' => self::MAX_AGE,
       ],
       // The dynamic page cache honours the max-age above, but the anonymous

--- a/web/modules/custom/simplytest_tugboat/src/LaunchRecorder.php
+++ b/web/modules/custom/simplytest_tugboat/src/LaunchRecorder.php
@@ -3,6 +3,7 @@
 namespace Drupal\simplytest_tugboat;
 
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\Core\Database\Connection;
 use Psr\Log\LoggerInterface;
 
@@ -18,6 +19,15 @@ final readonly class LaunchRecorder {
   public const string TABLE_NAME = 'simplytest_launch_record';
 
   /**
+   * Invalidated whenever a row is written.
+   *
+   * Launch records are not entities, so there is no list cache tag to reuse.
+   * Anything rendered from the table should carry this tag so the next launch
+   * clears it.
+   */
+  public const string CACHE_TAG = 'simplytest_launch_records';
+
+  /**
    * Tugboat accepted the launch and returned a preview.
    */
   public const string STATUS_LAUNCHED = 'launched';
@@ -31,6 +41,7 @@ final readonly class LaunchRecorder {
     private Connection $database,
     private TimeInterface $time,
     private LoggerInterface $logger,
+    private CacheTagsInvalidatorInterface $cacheTagsInvalidator,
   ) {
   }
 
@@ -85,7 +96,12 @@ final readonly class LaunchRecorder {
         '@project' => $record->project !== '' ? $record->project : $record->oneClickDemo,
         '@message' => $e->getMessage(),
       ]);
+      return;
     }
+    // A failed launch does not change the public report, but "the table
+    // changed, so the tag is invalidated" is a simpler rule than tracking
+    // which statuses each report reads.
+    $this->cacheTagsInvalidator->invalidateTags([self::CACHE_TAG]);
   }
 
 }

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchRecorderTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchRecorderTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\simplytest_tugboat\Kernel;
 
+use Drupal\Core\Cache\Cache;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_projects\ProjectTypes;
 use Drupal\simplytest_tugboat\LaunchRecord;
@@ -97,6 +98,21 @@ final class LaunchRecorderTest extends KernelTestBase {
     self::assertEquals('', $row->project);
     self::assertEquals('', $row->core_version);
     self::assertEquals('preview-ocd', $row->preview_id);
+  }
+
+  /**
+   * Writing a row invalidates whatever was rendered from the table.
+   *
+   * @covers ::recordLaunch
+   * @covers ::write
+   */
+  public function testRecordLaunchInvalidatesCacheTag(): void {
+    $cache = $this->container->get('cache.default');
+    $cache->set('report', 'stale', Cache::PERMANENT, [LaunchRecorder::CACHE_TAG]);
+
+    $this->recorder()->recordLaunch(LaunchRecord::forOneClickDemo('umami'), 'preview-ocd');
+
+    self::assertFalse($cache->get('report'));
   }
 
   /**

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchStatisticsControllerTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchStatisticsControllerTest.php
@@ -68,20 +68,19 @@ final class LaunchStatisticsControllerTest extends KernelTestBase {
   }
 
   /**
-   * The report is cached for a day, never by tag.
+   * The report is invalidated by launches and otherwise kept for a day.
    *
-   * Tagging it would mean every launch invalidated the page. The Expires
-   * header carries the same lifetime because the anonymous page cache ignores
-   * a render array's max-age and only reads that header.
+   * The Expires header carries the same lifetime because the anonymous page
+   * cache ignores a render array's max-age and only reads that header.
    *
    * @covers ::report
    */
-  public function testReportIsCachedByTime(): void {
+  public function testReportCacheability(): void {
     $now = $this->container->get('datetime.time')->getRequestTime();
     $build = LaunchStatisticsController::create($this->container)->report();
 
+    self::assertEquals([LaunchRecorder::CACHE_TAG], $build['#cache']['tags']);
     self::assertEquals(86400, $build['#cache']['max-age']);
-    self::assertArrayNotHasKey('tags', $build['#cache']);
     self::assertEquals(
       [['Expires', gmdate('D, d M Y H:i:s', $now + 86400) . ' GMT']],
       $build['#attached']['http_header']

--- a/web/modules/custom/simplytest_tugboat/tests/src/Unit/LaunchRecorderErrorTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Unit/LaunchRecorderErrorTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\simplytest_tugboat\Unit;
 
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\simplytest_tugboat\LaunchRecord;
 use Drupal\simplytest_tugboat\LaunchRecorder;
@@ -23,6 +24,8 @@ final class LaunchRecorderErrorTest extends UnitTestCase {
   use ProphecyTrait;
 
   /**
+   * Nothing was written, so nothing rendered from the table is stale either.
+   *
    * @covers ::recordLaunch
    * @covers ::write
    */
@@ -43,10 +46,14 @@ final class LaunchRecorderErrorTest extends UnitTestCase {
       ]
     )->shouldBeCalledOnce();
 
+    $invalidator = $this->prophesize(CacheTagsInvalidatorInterface::class);
+    $invalidator->invalidateTags([LaunchRecorder::CACHE_TAG])->shouldNotBeCalled();
+
     $recorder = new LaunchRecorder(
       $database->reveal(),
       $time->reveal(),
-      $logger->reveal()
+      $logger->reveal(),
+      $invalidator->reveal()
     );
 
     $recorder->recordLaunch(
@@ -84,7 +91,8 @@ final class LaunchRecorderErrorTest extends UnitTestCase {
       ['@project' => 'umami', '@message' => 'nope']
     )->shouldBeCalledOnce();
 
-    $recorder = new LaunchRecorder($database->reveal(), $time->reveal(), $logger->reveal());
+    $invalidator = $this->prophesize(CacheTagsInvalidatorInterface::class);
+    $recorder = new LaunchRecorder($database->reveal(), $time->reveal(), $logger->reveal(), $invalidator->reveal());
     $recorder->recordFailure(LaunchRecord::forOneClickDemo('umami'));
   }
 


### PR DESCRIPTION
## What changed

The `/statistics` report is now invalidated whenever a launch is recorded, instead of only expiring after a day.

## Why

After #607 deployed, the report was rendered once before any launch existed, and the anonymous page cache kept that empty page for 24 hours. Production has recorded six launches since the deploy, but the page still says "No launches recorded yet."

## How

Launch records are plain rows, not entities, so there is no list cache tag to reuse. `LaunchRecorder` gains a `CACHE_TAG` constant and invalidates it after each successful insert. A failed insert logs and returns before the invalidation, so nothing is cleared for a row that was never written. The controller adds the tag to its render array. The daily max-age and the matching `Expires` header stay, because the 30-day breakdown is date-based and still needs to roll over on days with no launches.

## Testing

- Kernel test sets a cache item carrying the tag, records a launch, and asserts the item is gone.
- Unit test asserts the invalidator is not called when the insert throws.
- Controller test asserts the render array carries the tag alongside the existing max-age.
- `simplytest_tugboat` suite, PHPStan, and Rector pass locally.

The current stale entry on production clears itself on the next launch after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
