### PR TITLE
List one click demos on the statistics report

### DIFF
--- a/web/modules/custom/simplytest_tugboat/components/launch-statistics/launch-statistics.component.yml
+++ b/web/modules/custom/simplytest_tugboat/components/launch-statistics/launch-statistics.component.yml
@@ -4,7 +4,7 @@ name: Launch statistics
 status: stable
 description: The public report of what people launch on simplytest.me.
 
-# The four tally props below repeat the same {name, total} shape. It is written
+# The five tally props below repeat the same {name, total} shape. It is written
 # out each time on purpose: only the props subtree is handed to the validator,
 # so a $ref pointing at a document-root definition cannot be resolved.
 props:
@@ -14,6 +14,7 @@ props:
     - totals
     - daily
     - daily_peak
+    - one_click_demos
     - projects
     - core_versions
     - install_profiles
@@ -58,6 +59,20 @@ props:
       title: Daily peak
       description: The busiest day's total, used to scale the bars. Never zero, so the template can divide by it.
       minimum: 1
+    one_click_demos:
+      type: array
+      title: One click demos
+      description: Demo launches, named by the demo's title rather than its plugin ID.
+      items:
+        type: object
+        required:
+          - name
+          - total
+        properties:
+          name:
+            type: string
+          total:
+            type: integer
     projects:
       type: array
       title: Most launched projects

--- a/web/modules/custom/simplytest_tugboat/components/launch-statistics/launch-statistics.twig
+++ b/web/modules/custom/simplytest_tugboat/components/launch-statistics/launch-statistics.twig
@@ -9,6 +9,7 @@
  * - totals: Launch counts keyed by 'week', 'window' and 'all_time'.
  * - daily: Per-day totals, oldest first, each with 'date' and 'total'.
  * - daily_peak: The busiest day's total, used to scale the bars.
+ * - one_click_demos: Top one click demos, each with 'name' and 'total'.
  * - projects: Top projects, each with 'name' and 'total'.
  * - core_versions: Top Drupal core releases, each with 'name' and 'total'.
  * - install_profiles: Top install profiles, each with 'name' and 'total'.
@@ -73,27 +74,52 @@
 
     <div class="mt-6 grid gap-6 lg:grid-cols-2">
 
-      <section class="rounded-xl border border-st-line bg-white p-6 shadow-card">
-        <h2 class="text-sm font-semibold text-st-body">Most launched projects</h2>
-        <p class="mt-1 font-mono text-[11px] uppercase tracking-[0.1em] text-st-faint">Last {{ window_days }} days</p>
-        <ol class="mt-5 space-y-2.5">
-          {% for project in projects %}
-            <li>
-              <div class="flex items-baseline justify-between gap-4 text-[13px]">
-                <a href="https://www.drupal.org/project/{{ project.name }}"
-                   class="font-medium text-st-slate hover:text-st-accent-dark">{{ project.name }}</a>
-                <span class="font-mono text-st-muted">{{ project.total|number_format }}</span>
-              </div>
-              <div class="mt-1 h-1.5 rounded-full bg-st-hairline2">
-                <div class="h-1.5 rounded-full bg-st-accent"
-                     style="width: {{ (project.total / projects|first.total * 100)|round }}%"></div>
-              </div>
-            </li>
-          {% else %}
-            <li class="text-[13px] text-st-muted">Nothing launched in this window.</li>
-          {% endfor %}
-        </ol>
-      </section>
+      <div class="space-y-6">
+
+        <section class="rounded-xl border border-st-line bg-white p-6 shadow-card">
+          <h2 class="text-sm font-semibold text-st-body">One click demos</h2>
+          <p class="mt-1 font-mono text-[11px] uppercase tracking-[0.1em] text-st-faint">Last {{ window_days }} days</p>
+          <ol class="mt-5 space-y-2.5">
+            {% for demo in one_click_demos %}
+              <li>
+                <div class="flex items-baseline justify-between gap-4 text-[13px]">
+                  <span class="font-medium text-st-slate">{{ demo.name }}</span>
+                  <span class="font-mono text-st-muted">{{ demo.total|number_format }}</span>
+                </div>
+                <div class="mt-1 h-1.5 rounded-full bg-st-hairline2">
+                  <div class="h-1.5 rounded-full bg-st-accent"
+                       style="width: {{ (demo.total / one_click_demos|first.total * 100)|round }}%"></div>
+                </div>
+              </li>
+            {% else %}
+              <li class="text-[13px] text-st-muted">No demos launched in this window.</li>
+            {% endfor %}
+          </ol>
+        </section>
+
+        <section class="rounded-xl border border-st-line bg-white p-6 shadow-card">
+          <h2 class="text-sm font-semibold text-st-body">Most launched projects</h2>
+          <p class="mt-1 font-mono text-[11px] uppercase tracking-[0.1em] text-st-faint">Last {{ window_days }} days</p>
+          <ol class="mt-5 space-y-2.5">
+            {% for project in projects %}
+              <li>
+                <div class="flex items-baseline justify-between gap-4 text-[13px]">
+                  <a href="https://www.drupal.org/project/{{ project.name }}"
+                     class="font-medium text-st-slate hover:text-st-accent-dark">{{ project.name }}</a>
+                  <span class="font-mono text-st-muted">{{ project.total|number_format }}</span>
+                </div>
+                <div class="mt-1 h-1.5 rounded-full bg-st-hairline2">
+                  <div class="h-1.5 rounded-full bg-st-accent"
+                       style="width: {{ (project.total / projects|first.total * 100)|round }}%"></div>
+                </div>
+              </li>
+            {% else %}
+              <li class="text-[13px] text-st-muted">Nothing launched in this window.</li>
+            {% endfor %}
+          </ol>
+        </section>
+
+      </div>
 
       <div class="space-y-6">
         {% set breakdowns = [

--- a/web/modules/custom/simplytest_tugboat/src/Controller/LaunchStatisticsController.php
+++ b/web/modules/custom/simplytest_tugboat/src/Controller/LaunchStatisticsController.php
@@ -4,6 +4,7 @@ namespace Drupal\simplytest_tugboat\Controller;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\simplytest_ocd\OneClickDemoPluginManager;
 use Drupal\simplytest_tugboat\LaunchRecorder;
 use Drupal\simplytest_tugboat\LaunchStatistics;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -35,6 +36,7 @@ final readonly class LaunchStatisticsController implements ContainerInjectionInt
   public function __construct(
     private LaunchStatistics $statistics,
     private TimeInterface $time,
+    private OneClickDemoPluginManager $demos,
   ) {
   }
 
@@ -46,6 +48,7 @@ final readonly class LaunchStatisticsController implements ContainerInjectionInt
     return new self(
       $container->get('simplytest_tugboat.launch_statistics'),
       $container->get('datetime.time'),
+      $container->get('plugin.manager.oneclickdemo'),
     );
   }
 
@@ -70,6 +73,7 @@ final readonly class LaunchStatisticsController implements ContainerInjectionInt
         ],
         'daily' => $daily,
         'daily_peak' => $this->peak($daily),
+        'one_click_demos' => $this->labelDemos($this->statistics->getTopOneClickDemos(self::WINDOW_DAYS, 10)),
         'projects' => $this->statistics->getTopProjects(self::WINDOW_DAYS, 20),
         'core_versions' => $this->statistics->getTopCoreVersions(self::WINDOW_DAYS, 10),
         'install_profiles' => $this->statistics->getTopInstallProfiles(self::WINDOW_DAYS, 10),
@@ -90,6 +94,26 @@ final readonly class LaunchStatisticsController implements ContainerInjectionInt
         ],
       ],
     ];
+  }
+
+  /**
+   * Swaps demo plugin IDs for their titles.
+   *
+   * A demo that was removed since it was launched keeps its ID as the label,
+   * which is still better than dropping it from the count.
+   *
+   * @param list<array{name: string, total: int}> $demos
+   *   Demo tallies keyed by plugin ID.
+   *
+   * @return list<array{name: string, total: int}>
+   *   The same tallies, named by plugin title.
+   */
+  private function labelDemos(array $demos): array {
+    $definitions = $this->demos->getDefinitions();
+    foreach ($demos as &$demo) {
+      $demo['name'] = (string) ($definitions[$demo['name']]['title'] ?? $demo['name']);
+    }
+    return $demos;
   }
 
   /**

--- a/web/modules/custom/simplytest_tugboat/src/LaunchStatistics.php
+++ b/web/modules/custom/simplytest_tugboat/src/LaunchStatistics.php
@@ -51,6 +51,18 @@ final readonly class LaunchStatistics {
   }
 
   /**
+   * Returns the most launched one click demos, most launched first.
+   *
+   * Names are plugin IDs. A demo that has since been removed still has rows,
+   * so the caller decides how to label an ID it no longer recognises.
+   *
+   * @return list<array{name: string, total: int}>
+   */
+  public function getTopOneClickDemos(int $days, int $limit): array {
+    return $this->topBy('one_click_demo', $days, $limit);
+  }
+
+  /**
    * Returns the most used Drupal core releases, most used first.
    *
    * @return list<array{name: string, total: int}>
@@ -130,8 +142,9 @@ final readonly class LaunchStatistics {
     $query->addField('r', $column, 'name');
     $query->addExpression('COUNT(*)', 'total');
     $query->condition('created_date', $this->firstDay($days), '>=');
-    // One click demos leave the project columns empty, so they would otherwise
-    // group together under a blank label.
+    // One click demos leave the project columns empty and normal launches
+    // leave the demo column empty, so either would otherwise group together
+    // under a blank label.
     $query->condition($column, '', '<>');
     $query->groupBy("r.$column");
     $query->orderBy('total', 'DESC');

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchStatisticsComponentTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchStatisticsComponentTest.php
@@ -54,6 +54,7 @@ final class LaunchStatisticsComponentTest extends KernelTestBase {
     $output = (string) $this->container->get('renderer')->renderRoot($build);
 
     self::assertStringContainsString('Launch statistics', $output);
+    self::assertStringContainsString('Drupal CMS', $output);
     self::assertStringContainsString('https://www.drupal.org/project/token', $output);
   }
 
@@ -145,6 +146,7 @@ final class LaunchStatisticsComponentTest extends KernelTestBase {
           ['date' => '2026-09-02', 'total' => 8],
         ],
         'daily_peak' => 8,
+        'one_click_demos' => [['name' => 'Drupal CMS', 'total' => 5]],
         'projects' => [['name' => 'token', 'total' => 12]],
         'core_versions' => [['name' => '10.3.0', 'total' => 12]],
         'install_profiles' => [['name' => 'standard', 'total' => 12]],

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchStatisticsControllerTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchStatisticsControllerTest.php
@@ -57,6 +57,25 @@ final class LaunchStatisticsControllerTest extends KernelTestBase {
   }
 
   /**
+   * Demos are listed by title, and a demo that no longer exists by its ID.
+   *
+   * @covers ::report
+   * @covers ::labelDemos
+   */
+  public function testReportListsOneClickDemosByTitle(): void {
+    $this->recordDemo('starshot');
+    $this->recordDemo('starshot');
+    $this->recordDemo('oneclickdemo_retired');
+
+    $output = $this->renderReport();
+
+    self::assertStringContainsString('Drupal CMS', $output);
+    self::assertStringNotContainsString('starshot', $output);
+    self::assertStringContainsString('oneclickdemo_retired', $output);
+    self::assertStringContainsString('Nothing launched in this window.', $output);
+  }
+
+  /**
    * Failed launches stay out of the public numbers.
    *
    * @covers ::report
@@ -93,19 +112,38 @@ final class LaunchStatisticsControllerTest extends KernelTestBase {
   }
 
   private function record(string $project, string $status = LaunchRecorder::STATUS_LAUNCHED): void {
+    $this->insert([
+      'project' => $project,
+      'project_type' => ProjectTypes::MODULE,
+      'project_version' => '8.x-1.0',
+      'core_version' => '10.3.0',
+      'install_profile' => 'standard',
+      'one_click_demo' => '',
+    ], $status);
+  }
+
+  private function recordDemo(string $plugin_id): void {
+    $this->insert([
+      'project' => '',
+      'project_type' => '',
+      'project_version' => '',
+      'core_version' => '',
+      'install_profile' => '',
+      'one_click_demo' => $plugin_id,
+    ], LaunchRecorder::STATUS_LAUNCHED);
+  }
+
+  /**
+   * @param array<string, string> $fields
+   */
+  private function insert(array $fields, string $status): void {
     $created = $this->container->get('datetime.time')->getRequestTime();
     $this->container->get('database')->insert(LaunchRecorder::TABLE_NAME)
-      ->fields([
+      ->fields($fields + [
         'created' => $created,
         'created_date' => gmdate('Y-m-d', $created),
         'status' => $status,
         'preview_id' => 'preview-abc',
-        'project' => $project,
-        'project_type' => ProjectTypes::MODULE,
-        'project_version' => '8.x-1.0',
-        'core_version' => '10.3.0',
-        'install_profile' => 'standard',
-        'one_click_demo' => '',
         'manual_install' => 0,
         'patch_count' => 0,
         'additional_count' => 0,

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchStatisticsTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchStatisticsTest.php
@@ -106,6 +106,28 @@ final class LaunchStatisticsTest extends KernelTestBase {
   }
 
   /**
+   * Demos are counted by plugin ID, and normal launches stay out of the list.
+   *
+   * @covers ::getTopOneClickDemos
+   * @covers ::topBy
+   */
+  public function testGetTopOneClickDemos(): void {
+    $this->record('token', daysAgo: 1);
+    $this->recordOneClickDemo('starshot', daysAgo: 1);
+    $this->recordOneClickDemo('starshot', daysAgo: 2);
+    $this->recordOneClickDemo('commerce', daysAgo: 1);
+    $this->recordOneClickDemo('umami', daysAgo: 40);
+
+    self::assertEquals(
+      [
+        ['name' => 'starshot', 'total' => 2],
+        ['name' => 'commerce', 'total' => 1],
+      ],
+      $this->statistics()->getTopOneClickDemos(30, 10)
+    );
+  }
+
+  /**
    * @covers ::getTopCoreVersions
    * @covers ::getTopInstallProfiles
    * @covers ::getProjectTypes


### PR DESCRIPTION
## What changed

The `/statistics` report gains a "One click demos" section, placed above "Most launched projects", listing each demo by its title with a count.

## Why

The headline total on production reads 7 launches, but the breakdown tables only add up to 3. The other 4 are one click demos. A demo records only its plugin ID and leaves the project, type, version, and profile columns empty, so every breakdown filtered them out and the report had nowhere else to show them.

## How

`LaunchStatistics::getTopOneClickDemos()` reuses the existing group-by helper on the demo column. The controller maps plugin IDs to titles through the one click demo plugin manager, so the page reads "Drupal CMS" instead of "starshot". A demo that was removed since it was launched keeps its ID as the label rather than dropping out of the count. The component schema gains a required `one_click_demos` prop with the same `{name, total}` shape as the others.

## Testing

- Kernel test for the new query: demos grouped and ordered by count, normal launches excluded, the window respected.
- Controller test renders with two Starshot launches and one retired demo ID, and asserts the title appears, the raw ID does not, and the retired ID falls back to itself.
- Component test's valid props include the new section.
- `simplytest_tugboat` suite, PHPStan, and Rector pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
