### PR TITLE
Drop prop-types, which React 19 never reads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "downshift": "^6.0.10",
-        "prop-types": "^15.8.1",
         "react": "^19.1.1",
         "react-dom": "^19.2.8"
       },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "downshift": "^6.0.10",
-    "prop-types": "^15.8.1",
     "react": "^19.1.1",
     "react-dom": "^19.2.8"
   },

--- a/web/themes/simplytest_theme/lib/components/AdvancedOptions.jsx
+++ b/web/themes/simplytest_theme/lib/components/AdvancedOptions.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import PropTypes from 'prop-types';
 
 import { useLauncher } from '../context/launcher';
 import AdditionalProjects from './AdditionalProjects';
@@ -24,12 +23,6 @@ function OptionGroup({ number, title, description, children }) {
     </section>
   );
 }
-OptionGroup.propTypes = {
-  number: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
-};
 
 function AdvancedOptions() {
   const { canLaunch, patches, setPatches } = useLauncher();

--- a/web/themes/simplytest_theme/lib/components/Patches.jsx
+++ b/web/themes/simplytest_theme/lib/components/Patches.jsx
@@ -1,5 +1,3 @@
-import PropTypes from 'prop-types';
-
 import { btnDashed, removeButton } from '../ui';
 
 // NOTE: We receive patches and setPatches as props, since this component is
@@ -87,11 +85,4 @@ function Patches({ patches, setPatches, idPrefix }) {
     </div>
   );
 }
-Patches.propTypes = {
-  patches: PropTypes.arrayOf(PropTypes.string).isRequired,
-  setPatches: PropTypes.func.isRequired,
-  // Must be unique across the page. There is no default on purpose: a shared
-  // fallback is exactly the collision this prop exists to prevent.
-  idPrefix: PropTypes.string.isRequired,
-};
 export default Patches;

--- a/web/themes/simplytest_theme/lib/components/ProgressPage/BuildLog.jsx
+++ b/web/themes/simplytest_theme/lib/components/ProgressPage/BuildLog.jsx
@@ -1,5 +1,3 @@
-import PropTypes from 'prop-types';
-
 import CopyButton from './CopyButton';
 
 function BuildLog({ logs, open, onToggle }) {
@@ -48,14 +46,5 @@ function BuildLog({ logs, open, onToggle }) {
     </div>
   );
 }
-BuildLog.propTypes = {
-  logs: PropTypes.arrayOf(
-    PropTypes.shape({
-      message: PropTypes.string.isRequired,
-    }),
-  ).isRequired,
-  open: PropTypes.bool.isRequired,
-  onToggle: PropTypes.func.isRequired,
-};
 
 export default BuildLog;

--- a/web/themes/simplytest_theme/lib/components/ProgressPage/CopyButton.jsx
+++ b/web/themes/simplytest_theme/lib/components/ProgressPage/CopyButton.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
-import PropTypes from 'prop-types';
 
-function CopyButton({ text, className, children }) {
+function CopyButton({ text, className = null, children }) {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef(null);
   useEffect(() => () => clearTimeout(timerRef.current), []);
@@ -23,13 +22,5 @@ function CopyButton({ text, className, children }) {
     </button>
   );
 }
-CopyButton.propTypes = {
-  text: PropTypes.string.isRequired,
-  className: PropTypes.string,
-  children: PropTypes.node.isRequired,
-};
-CopyButton.defaultProps = {
-  className: null,
-};
 
 export default CopyButton;

--- a/web/themes/simplytest_theme/lib/components/ProjectAutocomplete.jsx
+++ b/web/themes/simplytest_theme/lib/components/ProjectAutocomplete.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { useCombobox } from 'downshift';
-import PropTypes from 'prop-types';
 
 import { inputHero, inputPanel } from '../ui';
 import { debounce } from '../utils';
@@ -18,9 +17,9 @@ function fetchProjects(inputValue, callback) {
 }
 
 function ProjectAutocomplete({
-  initialProject,
+  initialProject = null,
   setSelectedItem,
-  additionalBtn,
+  additionalBtn = false,
 }) {
   const [inputItems, setInputItems] = useState([]);
   const [searched, setSearched] = useState(false);
@@ -193,15 +192,4 @@ function ProjectAutocomplete({
     </div>
   );
 }
-ProjectAutocomplete.defaultProps = {
-  initialProject: null,
-  additionalBtn: false,
-};
-ProjectAutocomplete.propTypes = {
-  initialProject: PropTypes.shape({
-    shortname: PropTypes.string.isRequired,
-  }),
-  setSelectedItem: PropTypes.func.isRequired,
-  additionalBtn: PropTypes.bool,
-};
 export default ProjectAutocomplete;

--- a/web/themes/simplytest_theme/lib/components/ProjectSelection.jsx
+++ b/web/themes/simplytest_theme/lib/components/ProjectSelection.jsx
@@ -1,16 +1,15 @@
 import { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
 
 import ProjectAutocomplete from './ProjectAutocomplete';
 import VersionSelector from './VersionSelector';
 
 function ProjectSelection({
   onChange,
-  appliedCoreConstraint,
-  additionalBtn,
-  initialDefaultProject,
-  initialDefaultVersion,
-  rootProjectVersion,
+  appliedCoreConstraint = null,
+  additionalBtn = false,
+  initialDefaultProject = null,
+  initialDefaultVersion = null,
+  rootProjectVersion = null,
 }) {
   const [project, setProject] = useState(initialDefaultProject);
   const [version, setVersion] = useState(initialDefaultVersion || '');
@@ -49,21 +48,4 @@ function ProjectSelection({
     </div>
   );
 }
-ProjectSelection.defaultProps = {
-  appliedCoreConstraint: null,
-  additionalBtn: false,
-  initialDefaultProject: null,
-  initialDefaultVersion: null,
-  rootProjectVersion: null,
-};
-ProjectSelection.propTypes = {
-  onChange: PropTypes.func.isRequired,
-  appliedCoreConstraint: PropTypes.string,
-  additionalBtn: PropTypes.bool,
-  initialDefaultProject: PropTypes.shape({
-    shortname: PropTypes.string.isRequired,
-  }),
-  initialDefaultVersion: PropTypes.string,
-  rootProjectVersion: PropTypes.string,
-};
 export default ProjectSelection;


### PR DESCRIPTION
## What changed

The `prop-types` package and every `propTypes` and `defaultProps` declaration in the theme are removed. The three components that had `defaultProps` now set the same defaults in their parameter lists.

## Why

React 19 removed propTypes checking and `defaultProps` support from function components. The declarations were dead code, and the defaults were silently not applied since the React 19 upgrade. This is the follow-up noted in #613, where the `react/prop-types` rule was turned off for the same reason.

## Behavior

Every default was `null` or `false`, and each consumer already handles an absent value the same way, so moving them into the signatures restores the original intent without changing any code path.

## Testing

`npm run lint` passes and `npm run build` succeeds. Cypress in CI covers the form. Deploys normally since the bundle changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
