### PR TITLE
Replace fixed waits in the Cypress specs with assertions

### DIFF
--- a/cypress/e2e/additional_projects.cy.js
+++ b/cypress/e2e/additional_projects.cy.js
@@ -15,15 +15,8 @@ describe('Tests additional projects and version constraints', () => {
     cy.getByLabel('Version').should('have.value', '4.0.3');
     cy.toggleAdvancedOptions();
     cy.get('button').contains('Add another project').click();
-    cy.get('#additional_project_0')
-      .getByLabel('Additional project name')
-      .type('Password Policy')
-      .wait(100)
-      .type(' Pwned')
-      .wait(2000)
-      .type('{downArrow}{enter}');
+    cy.pickAdditionalProject('additional_project_0', 'Password Policy Pwned');
 
-    cy.wait(400);
     cy.get('#additional_project_0 select').should('have.value', '2.0.1');
   });
 
@@ -34,15 +27,8 @@ describe('Tests additional projects and version constraints', () => {
     cy.pickProject('Password Policy');
     cy.toggleAdvancedOptions();
     cy.get('button').contains('Add another project').click();
-    cy.get('#additional_project_0')
-      .getByLabel('Additional project name')
-      .type('Password Policy')
-      .wait(100)
-      .type(' Pwned')
-      .wait(2000)
-      .type('{downArrow}{enter}');
+    cy.pickAdditionalProject('additional_project_0', 'Password Policy Pwned');
 
-    cy.wait(400);
     cy.get('#additional_project_0 input[type=url]')
       .should('exist')
       .and('have.value', '');
@@ -56,14 +42,7 @@ describe('Tests additional projects and version constraints', () => {
     cy.pickProject('Password Policy');
     cy.toggleAdvancedOptions();
     cy.get('button').contains('Add another project').click();
-    cy.get('#additional_project_0')
-      .getByLabel('Additional project name')
-      .type('Password Policy')
-      .wait(100)
-      .type(' Pwned')
-      .wait(2000)
-      .type('{downArrow}{enter}');
-    cy.wait(400);
+    cy.pickAdditionalProject('additional_project_0', 'Password Policy Pwned');
 
     cy.get('#additional_project_0 input[type=url]').type(patchUrl);
 
@@ -75,8 +54,8 @@ describe('Tests additional projects and version constraints', () => {
         .find((value) => value && value !== current);
       expect(other, 'a second release to switch to').to.be.a('string');
       cy.get('#additional_project_0 select').select(other);
+      cy.get('#additional_project_0 select').should('have.value', other);
     });
-    cy.wait(400);
 
     cy.get('#additional_project_0 input[type=url]').should(
       'have.value',
@@ -91,26 +70,21 @@ describe('Tests additional projects and version constraints', () => {
     cy.pickProject('Password Policy');
     cy.toggleAdvancedOptions();
     cy.get('button').contains('Add another project').click();
-    cy.get('#additional_project_0')
-      .getByLabel('Additional project name')
-      .type('Password Policy')
-      .wait(100)
-      .type(' Pwned')
-      .wait(2000)
-      .type('{downArrow}{enter}');
-    cy.wait(400);
+    cy.pickAdditionalProject('additional_project_0', 'Password Policy Pwned');
 
-    cy.get('input[type=url]').then(($inputs) => {
-      const ids = [...$inputs].map((input) => input.id);
-      expect(ids, 'every patch input has an id')
-        .to.have.length(2)
-        .and.to.not.include('');
-      expect(new Set(ids).size, 'distinct patch input ids').to.eq(2);
-      ids.forEach((id) => {
-        cy.get(`[id="${id}"]`).should('have.length', 1);
-        cy.get(`label[for="${id}"]`).should('have.length', 1);
+    cy.get('input[type=url]')
+      .should('have.length', 2)
+      .then(($inputs) => {
+        const ids = [...$inputs].map((input) => input.id);
+        expect(ids, 'every patch input has an id')
+          .to.have.length(2)
+          .and.to.not.include('');
+        expect(new Set(ids).size, 'distinct patch input ids').to.eq(2);
+        ids.forEach((id) => {
+          cy.get(`[id="${id}"]`).should('have.length', 1);
+          cy.get(`label[for="${id}"]`).should('have.length', 1);
+        });
       });
-    });
   });
 
   // #3494635: the format hint is rendered once per Patches instance, so the
@@ -119,25 +93,20 @@ describe('Tests additional projects and version constraints', () => {
     cy.pickProject('Password Policy');
     cy.toggleAdvancedOptions();
     cy.get('button').contains('Add another project').click();
-    cy.get('#additional_project_0')
-      .getByLabel('Additional project name')
-      .type('Password Policy')
-      .wait(100)
-      .type(' Pwned')
-      .wait(2000)
-      .type('{downArrow}{enter}');
-    cy.wait(400);
+    cy.pickAdditionalProject('additional_project_0', 'Password Policy Pwned');
 
-    cy.get('input[type=url]').then(($inputs) => {
-      const hintIds = [...$inputs].map((input) =>
-        input.getAttribute('aria-describedby'),
-      );
-      expect(hintIds).to.have.length(2);
-      expect(new Set(hintIds).size, 'distinct hint ids').to.eq(2);
-      hintIds.forEach((hintId) => {
-        cy.get(`[id="${hintId}"]`).should('have.length', 1).and('be.visible');
+    cy.get('input[type=url]')
+      .should('have.length', 2)
+      .then(($inputs) => {
+        const hintIds = [...$inputs].map((input) =>
+          input.getAttribute('aria-describedby'),
+        );
+        expect(hintIds).to.have.length(2);
+        expect(new Set(hintIds).size, 'distinct hint ids').to.eq(2);
+        hintIds.forEach((hintId) => {
+          cy.get(`[id="${hintId}"]`).should('have.length', 1).and('be.visible');
+        });
       });
-    });
   });
 
   // Rows used to key on the shortname, which is "" until a project is picked,
@@ -167,14 +136,7 @@ describe('Tests additional projects and version constraints', () => {
     cy.pickProject('Password Policy');
     cy.toggleAdvancedOptions();
     cy.get('button').contains('Add another project').click();
-    cy.get('#additional_project_0')
-      .getByLabel('Additional project name')
-      .type('Password Policy')
-      .wait(100)
-      .type(' Pwned')
-      .wait(2000)
-      .type('{downArrow}{enter}');
-    cy.wait(400);
+    cy.pickAdditionalProject('additional_project_0', 'Password Policy Pwned');
 
     cy.get('button').contains('Launch sandbox').click();
 

--- a/cypress/e2e/launch_form.cy.js
+++ b/cypress/e2e/launch_form.cy.js
@@ -60,9 +60,8 @@ describe('Test the launch form', function () {
     cy.getByLabel('Project patch 1').type(
       'https://www.drupal.org/files/issues/2020-12-07/3185080-3.patch',
     );
-    cy.wait(200);
     cy.get('button').contains('Add another patch').click();
-    cy.getByLabel('Project patch 2');
+    cy.get('input[type=url]').should('have.length', 2);
     // Select the remove buttons by accessible name. `cy.get()` always queries
     // from the document root, so the old `cy.get('#project_patch_1').get(...)`
     // was not scoped to that row and clicked the first × on the page twice.
@@ -130,14 +129,12 @@ describe('Test the launch form', function () {
     // Default Drupal 8 has Umami.
     cy.getByLabel('Version').select('8.x-1.6');
     cy.getByLabel('Drupal core').should('have.value', '8.9.20');
-    cy.wait(100);
     cy.getByLabel('Install profile').contains('Minimal');
     cy.getByLabel('Install profile').contains('Standard');
     cy.getByLabel('Install profile').contains('Umami Demo');
 
     // Drupal < 8.6 doesn't have Umami
     cy.getByLabel('Drupal core').select('8.5.9');
-    cy.wait(100);
     cy.getByLabel('Install profile').contains('Minimal');
     cy.getByLabel('Install profile').contains('Standard');
     cy.getByLabel('Install profile').contains('Umami Demo').should('not.exist');
@@ -145,7 +142,6 @@ describe('Test the launch form', function () {
     // Drupal 9 has Umami.
     cy.getByLabel('Version').select('8.x-1.11');
     cy.getByLabel('Drupal core').select('9.5.0');
-    cy.wait(100);
     cy.getByLabel('Install profile').contains('Minimal');
     cy.getByLabel('Install profile').contains('Standard');
     cy.getByLabel('Install profile').contains('Umami Demo');

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -35,6 +35,21 @@ Cypress.Commands.add('toggleAdvancedOptions', () => {
   return cy.contains('button', 'Advanced options').click();
 });
 
+// Picks a project in one additional project row. The row's version select
+// only renders once the project's releases have loaded, so waiting for it is
+// how a caller knows the pick has settled.
+Cypress.Commands.add('pickAdditionalProject', (rowId, input) => {
+  cy.intercept('GET', '**/simplytest/projects/autocomplete**').as(
+    'autocomplete',
+  );
+  cy.get(`#${rowId}`).within(() => {
+    cy.getByLabel('Additional project name').type(input);
+    cy.wait('@autocomplete');
+    cy.contains('[role="option"]', input).should('be.visible').click();
+    cy.get('select').should('exist');
+  });
+});
+
 Cypress.Commands.add('pickProject', (input) => {
   cy.intercept('GET', '**/simplytest/projects/autocomplete**').as(
     'autocomplete',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -77,11 +77,6 @@ export default defineConfig([
       'mocha/no-top-level-hooks': 'off',
       'mocha/max-top-level-suites': 'off',
       'mocha/no-exclusive-tests': 'error',
-      // The specs wait on fixed timers and chain actions in ways Cypress
-      // documents as flaky. Replacing those with assertions is a job of its
-      // own, so surface them without failing the build until then.
-      'cypress/no-unnecessary-waiting': 'warn',
-      'cypress/unsafe-to-chain-command': 'warn',
     },
   },
   // The Cypress entry point is the one ES module in that tree.


### PR DESCRIPTION
## What changed

Every `cy.wait(ms)` in the specs is gone, along with the type-pause-type chains, and the two Cypress lint rules that flagged them are now errors. This is the follow-up noted in #613.

## How

- A `pickAdditionalProject(rowId, input)` command does for an additional project row what `pickProject` already did for the main field: alias the autocomplete request, wait on it, click the option by its text, then wait for the row's version select. That select only renders once the project's releases have loaded, so its presence is the signal the old 400ms sleep was guessing at. Six copies of a seven-line block become one call each.
- The two tests that inspected the patch inputs with `.then()` now assert the expected count first, since `.then()` does not retry.
- The version switch test asserts the select shows the new release before checking the patch survived.
- The launch form's 100ms and 200ms pauses sat in front of `contains`, `should('not.exist')` and `getByLabel`, which all retry on their own.

## Testing

Both specs pass locally against ddev, 14 of 14, and the additional projects spec runs in 14 seconds instead of 30. `npm run lint` is clean with the promoted rules. Nothing here reaches the container, so the Lagoon deploy will be skipped at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
