### PR TITLE
Rank exact matches first in the project autocomplete (#3423286)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -494,21 +494,6 @@ parameters:
 			path: web/modules/custom/simplytest_projects/src/ProjectFetcher.php
 
 		-
-			message: "#^Method Drupal\\\\simplytest_projects\\\\ProjectFetcher\\:\\:searchFromProjects\\(\\) has parameter \\$string with no type specified\\.$#"
-			count: 1
-			path: web/modules/custom/simplytest_projects/src/ProjectFetcher.php
-
-		-
-			message: "#^Method Drupal\\\\simplytest_projects\\\\ProjectFetcher\\:\\:searchFromProjects\\(\\) has parameter \\$types with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: web/modules/custom/simplytest_projects/src/ProjectFetcher.php
-
-		-
-			message: "#^Method Drupal\\\\simplytest_projects\\\\ProjectFetcher\\:\\:searchFromProjects\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: web/modules/custom/simplytest_projects/src/ProjectFetcher.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between string and false will always evaluate to false\\.$#"
 			count: 1
 			path: web/modules/custom/simplytest_projects/src/ProjectFetcher.php

--- a/web/modules/custom/simplytest_projects/src/Controller/SimplyTestProjects.php
+++ b/web/modules/custom/simplytest_projects/src/Controller/SimplyTestProjects.php
@@ -74,7 +74,7 @@ class SimplyTestProjects implements ContainerInjectionInterface {
   public function autocompleteProjects(Request $request) {
     $matches = [];
     if ($string = $request->query->get('string')) {
-      $matches = $this->projectFetcher->searchFromProjects($string);
+      $matches = $this->projectFetcher->searchFromProjects((string) $string);
     }
     return new JsonResponse($matches);
   }

--- a/web/modules/custom/simplytest_projects/src/ProjectFetcher.php
+++ b/web/modules/custom/simplytest_projects/src/ProjectFetcher.php
@@ -261,28 +261,46 @@ class ProjectFetcher {
   /**
    * Searches from the list of existing projects.
    *
-   * @param $string
+   * @param string $string
    *  The prefix string to search projects for.
    * @param int $range
    *  Maximum number of results to return.
-   * @param array $types
+   * @param list<string>|null $types
    *  An array of project types to filter for.
    *
-   * @return array
-   *  An array of standard objects containing:
-   *   - title: The human readable project title.
-   *   - type: The projects type.
-   *   - shortname: The project machine/shortname.
-   *   - sandbox: Whether it's a sandbox.
+   * @return list<array{title: string, shortname: string, type: string}>
+   *  The matching projects, best match first.
    */
-  public function searchFromProjects($string, $range = 100, $types = NULL) {
+  public function searchFromProjects(string $string, int $range = 100, ?array $types = NULL): array {
+    $needle = strtolower(trim($string));
+    // Typed the way a title reads ("Link attributes") but compared against
+    // the shortname (link_attributes).
+    $shortname = str_replace([' ', '-'], '_', $needle);
+
     $query = $this->connection->select('simplytest_project', 'p')
       ->fields('p', [
         'title',
         'shortname',
         'type',
         'sandbox',
-      ])
+      ]);
+    // An exact match outranks everything, then shortnames that start with
+    // the search, then the rest by popularity. Sorting by usage alone let a
+    // popular partial match ("ai_provider_openai") bury the project actually
+    // asked for ("openai"), or push it past the range cap entirely.
+    // SUBSTR instead of LIKE so the expression needs no ESCAPE clause,
+    // which MySQL and SQLite spell differently.
+    $query->addExpression(
+      'CASE WHEN p.shortname = :exact_shortname OR LOWER(p.title) = :exact_title THEN 0 WHEN SUBSTR(p.shortname, 1, ' . strlen($shortname) . ') = :prefix THEN 1 ELSE 2 END',
+      'rank',
+      [
+        ':exact_shortname' => $shortname,
+        ':exact_title' => $needle,
+        ':prefix' => $shortname,
+      ],
+    );
+    $query
+      ->orderBy('rank', 'ASC')
       ->orderBy('usage', 'DESC')
       ->orderBy('sandbox', 'ASC')
       ->range(0, $range);
@@ -290,6 +308,7 @@ class ProjectFetcher {
     $title_or_shortname = new Condition('OR');
     $title_or_shortname->condition('title', '%' . $this->connection->escapeLike($string) . '%', 'LIKE');
     $title_or_shortname->condition('shortname', '%' . $this->connection->escapeLike($string) . '%', 'LIKE');
+    $title_or_shortname->condition('shortname', '%' . $this->connection->escapeLike($shortname) . '%', 'LIKE');
     $query->condition($title_or_shortname);
 
     if ($types) {
@@ -304,7 +323,7 @@ class ProjectFetcher {
 
     $projects = [];
     foreach ($results as $result) {
-      unset($result->sandbox);
+      unset($result->sandbox, $result->rank);
       $projects[] = (array) $result;
     }
 

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectFetcherTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectFetcherTest.php
@@ -240,6 +240,48 @@ final class ProjectFetcherTest extends KernelTestBase {
   }
 
   /**
+   * The project actually asked for outranks more popular partial matches.
+   *
+   * @covers ::searchFromProjects
+   */
+  public function testSearchRanksExactMatchFirst(): void {
+    $this->createProject('ai_provider_openai', 'OpenAI Provider', usage: 900);
+    $this->createProject('openai_client', 'OpenAI Client', usage: 700);
+    $this->createProject('openai', 'OpenAI', usage: 100);
+    $this->createProject('tmgmt_openai', 'TMGMT OpenAI', usage: 50);
+
+    // Exact shortname, then shortname prefix, then the rest by usage.
+    self::assertEquals(
+      ['openai', 'openai_client', 'ai_provider_openai', 'tmgmt_openai'],
+      array_column($this->sut->searchFromProjects('openai'), 'shortname'),
+    );
+    // An exact title counts too, whatever the case.
+    self::assertEquals('openai', $this->sut->searchFromProjects('OpenAI')[0]['shortname']);
+    // The exact match survives a range cap it would otherwise fall past.
+    self::assertEquals(['openai'], array_column($this->sut->searchFromProjects('openai', 1), 'shortname'));
+    // `rank` is an ordering detail, not part of the result.
+    self::assertArrayNotHasKey('rank', $this->sut->searchFromProjects('openai')[0]);
+  }
+
+  /**
+   * A search typed like a title still finds the shortname.
+   *
+   * @covers ::searchFromProjects
+   */
+  public function testSearchNormalizesShortname(): void {
+    $this->createProject('menu_link_attributes', 'Menu Link Attributes', usage: 900);
+    $this->createProject('link_attributes', 'Link Attributes widget', usage: 100);
+
+    foreach (['Link attributes', 'link-attributes', 'link_attributes'] as $search) {
+      self::assertEquals(
+        ['link_attributes', 'menu_link_attributes'],
+        array_column($this->sut->searchFromProjects($search), 'shortname'),
+        "Searching for '$search'",
+      );
+    }
+  }
+
+  /**
    * @covers ::searchFromProjects
    */
   public function testSearchFromProjectsFiltersByType(): void {


### PR DESCRIPTION
## What changed

The project autocomplete now puts an exact match first. Typing `openai` returns the OpenAI module ahead of `ai_provider_openai`, and typing "Link attributes" finds `link_attributes`.

## Why

Results were sorted by usage count alone. A popular partial match could bury the project someone actually typed, or push it past the 100-row cap so it never appeared at all. Reported in https://www.drupal.org/project/simplytest/issues/3423286 for Context and OpenAI, and again in 3423163 for link_attributes.

## How

A `CASE` expression in `searchFromProjects()` ranks rows: exact shortname or case-insensitive title first, shortname prefix second, everything else third. Usage still breaks ties, so the visible order for ordinary searches is unchanged. Ranking happens in SQL so the exact match is inside the range cap, not sorted after it.

The typed string is also normalized (lowercased, spaces and hyphens to underscores) and matched against the shortname, the same normalization the lookup endpoint applies. `SUBSTR` stands in for `LIKE` in the ranking expression because MySQL and SQLite spell the `ESCAPE` clause differently.

While in the method, its signature is typed and the three PHPStan baseline entries for it are removed.

## Testing notes

- New kernel tests cover the ranking order, title matches, the range cap, the stripped `rank` column, and the three spellings of "link attributes".
- Verified the same ranking against MariaDB in ddev with seeded `openai` projects, since kernel tests run on SQLite.
- PHPStan, Rector, and the full custom-module suite pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
