### PR TITLE
Index simplytest_project by shortname and timestamp

### DIFF
--- a/web/modules/custom/simplytest_projects/simplytest_projects.install
+++ b/web/modules/custom/simplytest_projects/simplytest_projects.install
@@ -12,6 +12,7 @@ use Drupal\Core\Database\Database;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\simplytest_projects\ProjectVersionManager;
+use Drupal\simplytest_projects\SimplytestProjectStorageSchema;
 
 /**
  * Implements hook_schema().
@@ -207,4 +208,15 @@ function simplytest_projects_update_9006(): void {
   $database->delete('queue')
     ->condition('name', 'simplytest_projects_project_refresher')
     ->execute();
+}
+
+/**
+ * Adds indexes on simplytest_project.shortname and .timestamp.
+ */
+function simplytest_projects_update_9007(): void {
+  $update_manager = \Drupal::entityDefinitionUpdateManager();
+  $entity_type = $update_manager->getEntityType('simplytest_project');
+  assert($entity_type !== NULL);
+  $entity_type->setHandlerClass('storage_schema', SimplytestProjectStorageSchema::class);
+  $update_manager->updateEntityType($entity_type);
 }

--- a/web/modules/custom/simplytest_projects/src/Entity/SimplytestProject.php
+++ b/web/modules/custom/simplytest_projects/src/Entity/SimplytestProject.php
@@ -23,6 +23,7 @@ use Drupal\simplytest_projects\Exception\EntityValidationException;
  *   fieldable = TRUE,
  *   admin_permission = "administer simplytest projects",
  *   handlers = {
+ *     "storage_schema" = "Drupal\simplytest_projects\SimplytestProjectStorageSchema",
  *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
  *     "list_builder" = "Drupal\simplytest_projects\SimplytestProjectListBuilder",
  *     "access" = "Drupal\Core\Entity\EntityAccessControlHandler",

--- a/web/modules/custom/simplytest_projects/src/SimplytestProjectStorageSchema.php
+++ b/web/modules/custom/simplytest_projects/src/SimplytestProjectStorageSchema.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\simplytest_projects;
+
+use Drupal\Core\Entity\ContentEntityTypeInterface;
+use Drupal\Core\Entity\Sql\SqlContentEntityStorageSchema;
+
+/**
+ * Adds indexes for the columns projects are looked up by.
+ *
+ * Every launch, deep link, and lookup selects a project by exact shortname,
+ * and cron selects stale projects by timestamp. Without these the table has
+ * only its primary key, so each of those is a full scan.
+ */
+final class SimplytestProjectStorageSchema extends SqlContentEntityStorageSchema {
+
+  /**
+   * {@inheritdoc}
+   *
+   * @param bool $reset
+   *
+   * @return array<string, array<string, mixed>>
+   */
+  #[\Override]
+  protected function getEntitySchema(ContentEntityTypeInterface $entity_type, $reset = FALSE): array {
+    $schema = parent::getEntitySchema($entity_type, $reset);
+    $schema[$this->storage->getBaseTable()]['indexes'] += [
+      'simplytest_project__shortname' => ['shortname'],
+      'simplytest_project__timestamp' => ['timestamp'],
+    ];
+    return $schema;
+  }
+
+}

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/SimplytestProjectStorageSchemaTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/SimplytestProjectStorageSchemaTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\simplytest_projects\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * @coversDefaultClass \Drupal\simplytest_projects\SimplytestProjectStorageSchema
+ * @group simplytest_projects
+ */
+final class SimplytestProjectStorageSchemaTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'simplytest_projects',
+    'system',
+    'user',
+  ];
+
+  /**
+   * A fresh install indexes the columns projects are looked up by.
+   *
+   * @covers ::getEntitySchema
+   */
+  public function testInstallCreatesLookupIndexes(): void {
+    $this->installEntitySchema('simplytest_project');
+
+    $schema = $this->container->get('database')->schema();
+    self::assertTrue($schema->indexExists('simplytest_project', 'simplytest_project__shortname'));
+    self::assertTrue($schema->indexExists('simplytest_project', 'simplytest_project__timestamp'));
+  }
+
+  /**
+   * The update hook adds the indexes to a table that predates them.
+   *
+   * Installs the entity type without the schema handler, the way every site
+   * before update 9007 was installed, then runs the update.
+   */
+  public function testUpdateAddsIndexesToExistingTable(): void {
+    $entity_type_manager = $this->container->get('entity_type.manager');
+    // Mutate the live definition rather than rebuilding it: a rebuild would
+    // read the handler back out of the annotation.
+    $entity_type_manager->getDefinition('simplytest_project')
+      ->setHandlerClass('storage_schema', NULL);
+    $this->installEntitySchema('simplytest_project');
+
+    $schema = $this->container->get('database')->schema();
+    self::assertFalse($schema->indexExists('simplytest_project', 'simplytest_project__shortname'));
+
+    // Now behave like a deploy: the code declares the handler, the installed
+    // definition does not, and the update hook reconciles them.
+    $entity_type_manager->clearCachedDefinitions();
+    $this->container->get('module_handler')->loadInclude('simplytest_projects', 'install');
+    simplytest_projects_update_9007();
+
+    self::assertTrue($schema->indexExists('simplytest_project', 'simplytest_project__shortname'));
+    self::assertTrue($schema->indexExists('simplytest_project', 'simplytest_project__timestamp'));
+  }
+
+}


### PR DESCRIPTION
## What changed

The `simplytest_project` table gains indexes on `shortname` and `timestamp`. A `storage_schema` handler declares them so fresh installs get them, and update hook 9007 adds them to existing sites.

## Why

The table had only its primary key. Every launch, `/project/{name}/{version}` deep link, and Drupal.org lookup selects a project by exact shortname, and cron selects stale projects by timestamp with a sort. Each of those was a full table scan.

The autocomplete is unchanged. Its leading-wildcard `LIKE` cannot use an index, so none is added for it.

## How

Same pattern as `commerce_log`: `SimplytestProjectStorageSchema` extends `SqlContentEntityStorageSchema` and adds the indexes in `getEntitySchema()`. The update hook takes the last-installed definition, sets the handler class on it, and calls `updateEntityType()`, which diffs the schema and creates only the missing indexes.

`shortname` gets a plain index, not a unique one. Duplicates are already refused by the entity's `UniqueField` constraint, and a unique index would change how a racing import fails and could refuse to build if production already holds a duplicate row.

## Testing notes

- Kernel test covers both paths: a fresh `installEntitySchema()` creates the indexes, and installing without the handler then running update 9007 adds them.
- Ran the update hook against the ddev MariaDB database, which was installed before this change. Both indexes appeared, and `EXPLAIN` on a shortname lookup switched from a full scan to the new index.
- PHPStan, Rector, and the full custom-module suite pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
