### PR TITLE
Do not redirect into a sandbox that is missing its patch

### DIFF
--- a/cypress/e2e/progress_patch_failure.cy.js
+++ b/cypress/e2e/progress_patch_failure.cy.js
@@ -1,0 +1,84 @@
+// The progress page decides on its own whether a finished build is worth
+// redirecting into. composer-patches aborts the build when a patch is refused,
+// so a refused patch normally arrives as a failed job — but that is a property
+// of the pinned major, and the pin has drifted out from under us once already.
+// These cover the guard that keeps a silently unpatched sandbox from looking
+// like a success.
+//
+// @see https://www.drupal.org/project/simplytest/issues/3388692
+const PROGRESS_PATH = '/tugboat/progress/instance-1/job-1';
+const PATCH_URL =
+  'https://git.drupalcode.org/issue/drupal-3273986/-/commit/7bd5d37bb6926152fd9cca21cc565824e6b034f2';
+
+// Enough of the Tugboat state payload for the page to render a finished build.
+function readyPreview(logMessages) {
+  return {
+    type: 'preview',
+    state: 'ready',
+    url: '/user/login',
+    progress: 100,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:01:00.000Z',
+    logs: logMessages.map((message, id) => ({ id, message })),
+  };
+}
+
+const CLEAN_LOG = [
+  'SIMPLYEST_STAGE_DOWNLOAD',
+  'SIMPLYEST_STAGE_PATCHING',
+  'SIMPLYEST_STAGE_INSTALLING',
+  'instance (simplytest) is ready',
+];
+
+const REFUSED_PATCH_LOG = [
+  ...CLEAN_LOG.slice(0, 2),
+  `  No available patcher was able to apply patch ${PATCH_URL}`,
+  ...CLEAN_LOG.slice(2),
+];
+
+describe('Progress page handling of a refused patch', function () {
+  it('does not redirect into a sandbox that is missing its patch', function () {
+    cy.intercept('GET', '/tugboat/status/**', readyPreview(REFUSED_PATCH_LOG));
+    // The redirect is a timer, so drive it rather than waiting it out.
+    cy.clock();
+    cy.visit(PROGRESS_PATH, {
+      qs: { project: 'drupal', version: '11.4.6', patch: PATCH_URL },
+    });
+
+    cy.contains('Your sandbox is ready, but the patch is not in it').should(
+      'be.visible',
+    );
+    cy.contains('Built without the patch').should('be.visible');
+
+    // The log carries the only explanation, so it opens without being asked.
+    cy.contains('No available patcher was able to apply patch').should(
+      'be.visible',
+    );
+
+    // The sandbox does exist, so both ways forward stay on offer.
+    cy.contains('a', 'Open sandbox').should('have.attr', 'href', '/user/login');
+    cy.contains('a', 'Fix the patch and rebuild').should(
+      'have.attr',
+      'href',
+      `/?project=drupal&version=11.4.6&patch=${encodeURIComponent(PATCH_URL)}`,
+    );
+
+    // Well past the redirect delay, the page is still here.
+    cy.tick(10000);
+    cy.location('pathname').should('eq', PROGRESS_PATH);
+  });
+
+  it('still redirects when every patch applied', function () {
+    cy.intercept('GET', '/tugboat/status/**', readyPreview(CLEAN_LOG));
+    cy.clock();
+    cy.visit(PROGRESS_PATH, {
+      qs: { project: 'drupal', version: '11.4.6', patch: PATCH_URL },
+    });
+
+    cy.contains('Your sandbox is ready').should('be.visible');
+    cy.contains('Opening it in a moment').should('be.visible');
+
+    cy.tick(10000);
+    cy.location('pathname', { timeout: 10000 }).should('eq', '/user/login');
+  });
+});

--- a/web/themes/simplytest_theme/lib/components/ProgressPage/InstanceProgress.jsx
+++ b/web/themes/simplytest_theme/lib/components/ProgressPage/InstanceProgress.jsx
@@ -47,6 +47,14 @@ function logLines(logs) {
     .filter((line) => line !== '' && !USAGE_SYNOPSIS.test(line));
 }
 
+// composer-patches 2.x aborts the build when no patcher will take a patch, so
+// this usually shows up on a failed job. It can still land on a successful one:
+// 1.x skipped refused patches by default, and the pinned major has drifted out
+// from under us once already.
+function patchFailed(logs) {
+  return logLines(logs || []).some((line) => PATCH_FAILURE.test(line));
+}
+
 // The lines that actually say what went wrong, rather than the last ones.
 function failureExcerpt(logs) {
   const lines = logLines(logs);
@@ -311,7 +319,10 @@ function InstanceProgress() {
       // A preview means the job finished; a failed job never becomes one.
       // Either way the state is final and polling must stop.
       if (json.type === 'preview') {
-        if (json.url && json.state === 'ready') {
+        // Whoever passed a patch is here for the patch. A sandbox built without
+        // it is not what they asked for, so hold the page and let them read the
+        // log rather than dropping them into a site that looks fine.
+        if (json.url && json.state === 'ready' && !patchFailed(json.logs)) {
           setTimeout(() => {
             window.location.href = json.url;
           }, 3000);
@@ -336,13 +347,16 @@ function InstanceProgress() {
   const failed = state.state === 'failed';
   const ready =
     state.type === 'preview' && state.state === 'ready' && state.url;
+  // Built and running, but without the patch that was asked for.
+  const patchSkipped = Boolean(ready) && patchFailed(state.logs);
 
-  // A failed build lands with the log open.
+  // A failed build lands with the log open, and so does a skipped patch: the
+  // log is the only place that names the patch that was refused.
   useEffect(() => {
-    if (failed) {
+    if (failed || patchSkipped) {
       setLogOpen(true);
     }
-  }, [failed]);
+  }, [failed, patchSkipped]);
 
   if (error) {
     return (
@@ -368,14 +382,31 @@ function InstanceProgress() {
   if (ready) {
     const duration = formatDuration(state.createdAt, state.updatedAt);
     const expiry = formatExpiry(state.createdAt);
+    const readyEyebrow = duration ? `Ready in ${duration}` : 'Ready';
     return (
       <PageColumn>
         <PageHeading
-          eyebrow={duration ? `Ready in ${duration}` : 'Ready'}
-          eyebrowClass="text-st-success"
-          title="Your sandbox is ready"
+          eyebrow={patchSkipped ? 'Built without the patch' : readyEyebrow}
+          eyebrowClass={patchSkipped ? 'text-st-danger' : 'text-st-success'}
+          title={
+            patchSkipped
+              ? 'Your sandbox is ready, but the patch is not in it'
+              : 'Your sandbox is ready'
+          }
         >
-          Opening it in a moment. You&rsquo;re signed in as an administrator.
+          {patchSkipped ? (
+            <>
+              The build came up, but the patch was refused, so this sandbox is
+              running unpatched. The log below names the patch and says why. We
+              have not opened it for you &mdash; the link is there if you want
+              it anyway.
+            </>
+          ) : (
+            <>
+              Opening it in a moment. You&rsquo;re signed in as an
+              administrator.
+            </>
+          )}
         </PageHeading>
 
         <div className="flex flex-col gap-4 rounded-[14px] border border-st-accent-line bg-st-accent-tint2 p-6">
@@ -402,6 +433,17 @@ function InstanceProgress() {
             </div>
           )}
         </div>
+
+        {patchSkipped && submission.project && (
+          <div className="flex flex-wrap items-center gap-3">
+            <a
+              href={prefillUrl(submission)}
+              className={`${btnSecondary} px-5 py-3.5 text-[15px]`}
+            >
+              Fix the patch and rebuild
+            </a>
+          </div>
+        )}
 
         {submission.project && (
           <div className="flex items-center justify-between gap-6 rounded-xl border border-st-line px-5 py-[18px]">


### PR DESCRIPTION
Closes the last open thread on [#3388692](https://www.drupal.org/project/simplytest/issues/3388692).

## What changed

A finished build whose log says a patch was refused no longer auto-redirects into the sandbox. It renders as built-but-unpatched, opens the build log, and offers both the sandbox link and a prefilled link back to the form.

## Why

Most of #3388692 is already fixed. I ran the reporter's exact repro against production — Drupal core 11.4.6 with their bad commit URL as the patch — and got:

```
type=preview  state=failed  progress=40
Command Failed (Tugboat Error 1064): Exit code: 1; Command: cd stm && composer update --no-ansi -v
```

```
In Patches.php line 288:
  No available patcher was able to apply patch https://git.drupalcode.org/iss…
```

No redirect, log auto-opens, `failureExcerpt` anchors on the exception header, patch-specific headline fires. The build dies at 40%, before the sandbox is even installed.

That all rests on one thing: composer-patches 2.x *aborts* when a patch is refused. 1.x skipped by default, and the pin drifted from 1.x to 2.x on its own once already (#3588836), which is why `PreviewConfigGenerator::COMPOSER_PATCHES` is pinned on purpose. If it ever drifts back, a refused patch becomes a *successful* build, and the old behaviour returns silently: green "Your sandbox is ready" and a 3-second redirect into a sandbox quietly missing the patch the user came for.

The ready branch never looked at the log. Now it does, so the invariant is enforced where it matters instead of assumed.

## How

`patchFailed(logs)` was inline in the failed branch; it is now a named helper used by both. The redirect requires `!patchFailed(json.logs)`, and `patchSkipped` drives the heading, the auto-opened log, and the retry link.

Worth noting the "proceed to the instance anyway" button the reporter originally asked for only makes sense in this state — when the patch aborts the build there is no instance to proceed to. It arrives here as the existing **Open sandbox** link.

## Testing

New `cypress/e2e/progress_patch_failure.cy.js` stubs the Tugboat state endpoint. The progress controller renders a static mount with no Tugboat call, so this is cheap; `cy.clock`/`cy.tick` drives the redirect timer instead of waiting it out, so the spec runs in ~1s.

- New spec: 2 passing.
- Reverted the guard and re-ran: test 1 fails, test 2 still passes. Not a vacuous test.
- Full suite: 23 passing across all 6 specs. `npm run lint` clean.

No PHP touched. The guard itself can only be exercised through the stub — production cannot produce a soft-skip today, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)