### PR TITLE
Issue #3265514: Hold the launch button while an extra project is incomplete

### DIFF
--- a/cypress/e2e/additional_projects.cy.js
+++ b/cypress/e2e/additional_projects.cy.js
@@ -148,4 +148,28 @@ describe('Tests additional projects and version constraints', () => {
         expect(projects[0].shortname).to.eq('password_policy_pwned');
       });
   });
+
+  // #3265514: an empty row used to submit, and the backend answered with raw
+  // constraint messages naming a property path. The button holds instead.
+  it('should not launch while an additional project is incomplete', function () {
+    cy.pickProject('Password Policy');
+    cy.get('button').contains('Launch sandbox').should('be.enabled');
+
+    cy.toggleAdvancedOptions();
+    cy.get('button').contains('Add another project').click();
+    cy.get('button').contains('Launch sandbox').should('be.disabled');
+
+    cy.pickAdditionalProject('additional_project_0', 'Password Policy Pwned');
+    cy.get('button').contains('Launch sandbox').should('be.enabled');
+  });
+
+  it('should launch again once an incomplete additional project is removed', function () {
+    cy.pickProject('Password Policy');
+    cy.toggleAdvancedOptions();
+    cy.get('button').contains('Add another project').click();
+    cy.get('button').contains('Launch sandbox').should('be.disabled');
+
+    cy.get('[aria-label="Remove additional project 1"]').click();
+    cy.get('button').contains('Launch sandbox').should('be.enabled');
+  });
 });

--- a/web/themes/simplytest_theme/lib/components/Launcher/Launcher.jsx
+++ b/web/themes/simplytest_theme/lib/components/Launcher/Launcher.jsx
@@ -32,7 +32,7 @@ function Launcher() {
   const [errors, setErrors] = useState([]);
   const [submitting, setSubmitting] = useState(false);
   const {
-    canLaunch,
+    canSubmit,
     getLaunchPayload,
     selectedProject,
     selectedVersion,
@@ -114,7 +114,7 @@ function Launcher() {
             />
             <button
               className={`${btnPrimary} whitespace-nowrap`}
-              disabled={!canLaunch || submitting}
+              disabled={!canSubmit || submitting}
             >
               {submitting ? 'Launching…' : 'Launch sandbox'}
             </button>

--- a/web/themes/simplytest_theme/lib/context/launcher.jsx
+++ b/web/themes/simplytest_theme/lib/context/launcher.jsx
@@ -56,6 +56,19 @@ export function LauncherProvider({ children }) {
     setCanLaunch(selectedProject && selectedVersion);
   }, [selectedVersion, selectedProject]);
 
+  // "Add another project" inserts an empty row. Submitting with one posts empty
+  // strings, and the backend answers with the raw constraint messages
+  // ("additionalProjects.0.shortname: This value should not be blank.") that
+  // #3265514 reported as cryptic. Hold the submit button until every row names
+  // a project and a version. Dropping incomplete rows from the payload instead
+  // would launch a sandbox missing a project the user believes they added.
+  //
+  // Kept separate from `canLaunch`, which gates the advanced options panel: an
+  // incomplete row must not collapse the panel that row lives in.
+  const canSubmit =
+    Boolean(canLaunch) &&
+    additionalProjects.every((project) => project.shortname && project.version);
+
   function getLaunchPayload() {
     return {
       project: {
@@ -89,6 +102,7 @@ export function LauncherProvider({ children }) {
         manualInstall,
         setManualInstall,
         canLaunch,
+        canSubmit,
         additionalProjects,
         setAdditionalProjects,
         getLaunchPayload,


### PR DESCRIPTION
Fixes the second half of [#3265514](https://www.drupal.org/project/simplytest/issues/3265514), reported from Florida DrupalCamp 2022.

## What changed

Clicking "Add another project" and leaving the row empty no longer submits. The launch button stays disabled until every extra project row names a project and a version, the same bar the root project already clears.

## Why

An empty row posts empty strings. `ProjectInfoDefinition` rejects them, and `UnprocessableHttpExceptionSubscriber` renders each violation as `propertyPath: message`, so the user got `additionalProjects.0.shortname: This value should not be blank.` That is the "two error messages" from the issue's screenshot.

Dropping incomplete rows from the payload instead would launch a sandbox silently missing a project the user believes they added, so the button holds rather than the payload being filtered.

The first half of the issue, not being able to select the only available version for a dev-only project, was already fixed by the version fall-through in `VersionSelector`.

## How

`canSubmit` is a new context value for the submit button. `canLaunch` keeps its existing job of gating the advanced options panel.

Those have to stay separate. `AdvancedOptions` uses `canLaunch` for both `disabled` and `expanded`, so folding the row check into `canLaunch` collapses the panel the instant a row is added, hiding the row the user just created and the × that would remove it. I hit exactly that on the first attempt: all nine specs in `additional_projects.cy.js` failed.

## Testing notes

Two specs added to `cypress/e2e/additional_projects.cy.js`: adding an empty row disables launch and filling it re-enables, and removing an incomplete row re-enables.

Verified locally against ddev: 9 passing. Confirmed non-vacuous by pointing the button back at `canLaunch`, which fails the two new specs and passes the other seven.