### PR TITLE
Offer the drupal.org lookup when no result matches exactly

### DIFF
--- a/cypress/e2e/project_autocomplete.cy.js
+++ b/cypress/e2e/project_autocomplete.cy.js
@@ -84,4 +84,41 @@ describe('Look up on drupal.org button', () => {
     );
     cy.getByLabel('Version').should('exist');
   });
+
+  // The search matches substrings, so an unknown project whose name is
+  // contained in another project's name returned that neighbour and nothing
+  // else. A non-empty list used to suppress the lookup, leaving no way to
+  // reach the project actually asked for. Reported for "fox", which found
+  // foxycart and spreadfirefox but offered no way to reach fox.
+  it('offers the lookup when no result matches exactly', () => {
+    cy.request('POST', '/simplytest/projects/lookup', { name: 'pathauto' });
+    cy.visit('/');
+    cy.getByLabel('Module, theme or distribution').type('path');
+
+    // The substring match is listed, and the lookup is still offered.
+    cy.contains('[role="option"]', 'Pathauto').should('be.visible');
+    cy.contains('button', 'Look up “path” on drupal.org').should('be.visible');
+  });
+
+  it('drops the lookup once a result matches exactly', () => {
+    cy.request('POST', '/simplytest/projects/lookup', { name: 'pathauto' });
+    cy.visit('/');
+    cy.getByLabel('Module, theme or distribution').type('pathauto');
+
+    cy.contains('[role="option"]', 'Pathauto').should('be.visible');
+    cy.contains('button', 'Look up').should('not.exist');
+  });
+
+  it('treats a typed title as the shortname it normalizes to', () => {
+    cy.request('POST', '/simplytest/projects/lookup', {
+      name: 'password_policy',
+    });
+    cy.visit('/');
+    // Spaces normalize to underscores the way searchFromProjects() does, so
+    // this is an exact match on password_policy and needs no lookup.
+    cy.getByLabel('Module, theme or distribution').type('password policy');
+
+    cy.contains('[role="option"]', 'Password Policy').should('be.visible');
+    cy.contains('button', 'Look up').should('not.exist');
+  });
 });

--- a/web/themes/simplytest_theme/lib/components/ProjectAutocomplete.jsx
+++ b/web/themes/simplytest_theme/lib/components/ProjectAutocomplete.jsx
@@ -116,8 +116,19 @@ function ProjectAutocomplete({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialProject]);
 
-  const showLookup =
-    searched && inputItems.length === 0 && inputValue.trim().length >= 3;
+  // The search matches substrings, so a project the site does not know about
+  // still returns its neighbours: "fox" finds foxycart and spreadfirefox but
+  // not fox itself. Offering the lookup only on an empty list made every such
+  // project unreachable, so offer it whenever nothing matches exactly.
+  // Normalized the way searchFromProjects() normalizes, so "Fox Drush" and
+  // "fox-drush" count as the same typed name the backend would compare.
+  const needle = inputValue.trim().toLowerCase();
+  const needleShortname = needle.replace(/[ -]/g, '_');
+  const hasExactMatch = inputItems.some(
+    (item) =>
+      item.shortname === needleShortname || item.title.toLowerCase() === needle,
+  );
+  const showLookup = searched && !hasExactMatch && needle.length >= 3;
   // Clicking the input toggles the menu even when there is nothing to list,
   // so only draw the panel when it has rows.
   const menuVisible = isOpen && (inputItems.length > 0 || showLookup);


### PR DESCRIPTION
## What changed

The "Look up … on drupal.org" option now appears whenever no result matches the typed name exactly, instead of only when the search returns nothing at all.

## Why

Reported by a user on LinkedIn: they could not launch [fox](https://www.drupal.org/project/fox), and saw no options for it despite the "Any project on drupal.org" label.

The search matches substrings. Production returns six rows for `fox`, none of them fox:

```
foxycart | FoxyPal
spreadfirefox | SpreadFirefox
synfox | SynFox
spreadthefox | Spread The Fox
media_foxnews | Media: Fox News
3123658 | Increase Hindi font in Firefox
```

`showLookup` required `inputItems.length === 0`, so those six rows suppressed the lookup and there was no way to reach the project. The autocomplete only searches projects the site has already imported (#587), so this hits any uncached project whose name is a substring of another project's name. That is a large class of short or common names. Deep links were unaffected, since they run the lookup explicitly.

It is not the three-letter theory the reporter guessed at: the `>= 3` gate passes at exactly 3 characters.

## How

Compare the typed value against the results for an exact shortname or title match, normalizing the way `ProjectFetcher::searchFromProjects()` does (lowercase, spaces and dashes to underscores). So "Password Policy" and "password-policy" both count as an exact match on `password_policy` and correctly need no lookup.

## Testing notes

Three specs added to `cypress/e2e/project_autocomplete.cy.js`: the lookup is offered when only a substring match is listed, dropped once an exact match is listed, and dropped for a typed title that normalizes to a known shortname.

Verified locally against ddev, 7 passing. Confirmed non-vacuous by restoring the `length === 0` condition, which fails the first of the three.

`fox` itself is already reachable on production: I ran the lookup the button would have run while investigating, so it is now cached and ranks first.