### PR TITLE
Add drupal-rector, and the toolchain bump it requires

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
     },
     "require-dev": {
         "drupal/core-dev": "^11",
-        "rector/rector": "^1.2"
+        "palantirnet/drupal-rector": "^1.1",
+        "rector/rector": "^2.0"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c609c64afe256629c902a063cea83f67",
+    "content-hash": "254855ee0f9e720e2298b39d7ae58689",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -8617,37 +8617,37 @@
         },
         {
             "name": "mglaman/phpstan-drupal",
-            "version": "1.3.9",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mglaman/phpstan-drupal.git",
-                "reference": "973a4e89e19ea7dbd60af0aa939b18a873cf7f2f"
+                "reference": "d5b72bea7b8c8b2c21599b890af030f335a97395"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mglaman/phpstan-drupal/zipball/973a4e89e19ea7dbd60af0aa939b18a873cf7f2f",
-                "reference": "973a4e89e19ea7dbd60af0aa939b18a873cf7f2f",
+                "url": "https://api.github.com/repos/mglaman/phpstan-drupal/zipball/d5b72bea7b8c8b2c21599b890af030f335a97395",
+                "reference": "d5b72bea7b8c8b2c21599b890af030f335a97395",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.1",
-                "phpstan/phpstan": "^1.12",
-                "phpstan/phpstan-deprecation-rules": "^1.1.4",
-                "symfony/finder": "^4.2 || ^5.0 || ^6.0 || ^7.0",
-                "symfony/yaml": "^4.2|| ^5.0 || ^6.0 || ^7.0",
-                "webflo/drupal-finder": "^1.3.1"
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "symfony/finder": "^6.2 || ^7.0 || ^8.0",
+                "symfony/yaml": "^6.2 || ^7.0 || ^8.0",
+                "webflo/drupal-finder": "^1.3.1 || ^2.0"
             },
             "require-dev": {
-                "behat/mink": "^1.8",
-                "composer/installers": "^1.9",
-                "drupal/core-recommended": "^10",
-                "drush/drush": "^10.0 || ^11 || ^12 || ^13@beta",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan-strict-rules": "^1.0",
-                "phpunit/phpunit": "^8.5 || ^9 || ^10 || ^11",
-                "slevomat/coding-standard": "^7.1",
-                "squizlabs/php_codesniffer": "^3.3",
-                "symfony/phpunit-bridge": "^4.4 || ^5.4 || ^6.0 || ^7.0"
+                "behat/mink": "^1.10",
+                "composer/installers": "^1.9 || ^2",
+                "drupal/core-recommended": "^11",
+                "drush/drush": "^11 || ^12 || ^13",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9 || ^10 || ^11",
+                "slevomat/coding-standard": "^8.6",
+                "squizlabs/php_codesniffer": "^3.7",
+                "symfony/phpunit-bridge": "^6.2 || ^7.0 || ^8.0"
             },
             "suggest": {
                 "jangregor/phpstan-prophecy": "Provides a prophecy/prophecy extension for phpstan/phpstan.",
@@ -8661,9 +8661,6 @@
                         "extension.neon",
                         "rules.neon"
                     ]
-                },
-                "branch-alias": {
-                    "dev-main": "1.0-dev"
                 },
                 "installer-paths": {
                     "tests/fixtures/drupal/core": [
@@ -8701,7 +8698,7 @@
             "description": "Drupal extension and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/mglaman/phpstan-drupal/issues",
-                "source": "https://github.com/mglaman/phpstan-drupal/tree/1.3.9"
+                "source": "https://github.com/mglaman/phpstan-drupal/tree/2.2.0"
             },
             "funding": [
                 {
@@ -8717,7 +8714,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-22T16:48:16+00:00"
+            "time": "2026-09-09T14:50:40+00:00"
         },
         {
             "name": "micheh/phpcs-gitlab",
@@ -9362,6 +9359,94 @@
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
             "time": "2026-09-09T22:06:17+00:00"
+        },
+        {
+            "name": "palantirnet/drupal-rector",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/palantirnet/drupal-rector.git",
+                "reference": "c13b82014e9ab3b89768d5047aef9d4814c2e905"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/palantirnet/drupal-rector/zipball/c13b82014e9ab3b89768d5047aef9d4814c2e905",
+                "reference": "c13b82014e9ab3b89768d5047aef9d4814c2e905",
+                "shasum": ""
+            },
+            "require": {
+                "rector/rector": "^2",
+                "webflo/drupal-finder": "^1.2"
+            },
+            "conflict": {
+                "rector/rector": ">=2.6.2"
+            },
+            "replace": {
+                "drupal8-rector/drupal8-rector": "*",
+                "palantirnet/drupal8-rector": "*"
+            },
+            "require-dev": {
+                "cweagans/composer-patches": "^2.0",
+                "friendsofphp/php-cs-fixer": "^3.95.1",
+                "php": "^8.2",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.54",
+                "phpstan/phpstan-deprecation-rules": "^2.0.4",
+                "phpunit/phpunit": "^12.5.24",
+                "symfony/yaml": "^5 || ^6 || ^7.4.8",
+                "symplify/vendor-patches": "^12.0.6"
+            },
+            "type": "rector-extension",
+            "extra": {
+                "enable-patching": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "DrupalRector\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dezső Biczó",
+                    "email": "mxr576@gmail.com"
+                },
+                {
+                    "name": "Ofer Shaal",
+                    "email": "shaal@palantir.net"
+                },
+                {
+                    "name": "Daniel Montgomery",
+                    "email": "montgomery@palantir.net"
+                },
+                {
+                    "name": "Matt Glaman",
+                    "email": "nmd.matt@gmail.com"
+                },
+                {
+                    "name": "Björn Brala",
+                    "email": "drupal@bjorn.dev"
+                },
+                {
+                    "name": "Ken Rickard",
+                    "email": "agentrickard@gmail.com"
+                }
+            ],
+            "description": "Instant fixes for your Drupal code by using Rector.",
+            "keywords": [
+                "Code style",
+                "ast",
+                "drupal",
+                "rector"
+            ],
+            "support": {
+                "issues": "https://github.com/palantirnet/drupal-rector/issues",
+                "source": "https://github.com/palantirnet/drupal-rector/tree/1.1.3"
+            },
+            "time": "2026-09-03T11:32:43+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -10127,15 +10212,15 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.34",
+            "version": "2.2.13",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/4dd89ca7aa30fdc6760be21550d583bcc32e8476",
-                "reference": "4dd89ca7aa30fdc6760be21550d583bcc32e8476",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9ba9ac76ee9c5cf5b56d58eb5deec6315b7a0260",
+                "reference": "9ba9ac76ee9c5cf5b56d58eb5deec6315b7a0260",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0"
+                "php": "^7.4|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -10153,6 +10238,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -10176,30 +10272,31 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-28T10:04:39+00:00"
+            "time": "2026-09-03T20:38:19+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
-            "version": "1.2.1",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
-                "reference": "f94d246cc143ec5a23da868f8f7e1393b50eaa82"
+                "reference": "67bedd65c24bc72840afc45aed48b1059dd44bec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/f94d246cc143ec5a23da868f8f7e1393b50eaa82",
-                "reference": "f94d246cc143ec5a23da868f8f7e1393b50eaa82",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/67bedd65c24bc72840afc45aed48b1059dd44bec",
+                "reference": "67bedd65c24bc72840afc45aed48b1059dd44bec",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.12"
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.39"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^9.5"
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "shipmonk/name-collision-detector": "^2.1"
             },
             "type": "phpstan-extension",
             "extra": {
@@ -10219,38 +10316,44 @@
                 "MIT"
             ],
             "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "keywords": [
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.2.1"
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/2.0.5"
             },
-            "time": "2024-09-11T15:52:35+00:00"
+            "time": "2026-07-22T06:50:43+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "1.4.2",
+            "version": "2.0.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "72a6721c9b64b3e4c9db55abbc38f790b318267e"
+                "reference": "f5dc20ff8082d02339b60cab68ec3eb0d859fb30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/72a6721c9b64b3e4c9db55abbc38f790b318267e",
-                "reference": "72a6721c9b64b3e4c9db55abbc38f790b318267e",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/f5dc20ff8082d02339b60cab68ec3eb0d859fb30",
+                "reference": "f5dc20ff8082d02339b60cab68ec3eb0d859fb30",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.12"
+                "phar-io/version": "^3.2",
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.2.3"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.0"
             },
             "require-dev": {
-                "nikic/php-parser": "^4.13.0",
+                "nikic/php-parser": "^5",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/phpstan-strict-rules": "^1.5.1",
-                "phpunit/phpunit": "^9.5"
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "shipmonk/name-collision-detector": "^2.1"
             },
             "type": "phpstan-extension",
             "extra": {
@@ -10271,11 +10374,14 @@
                 "MIT"
             ],
             "description": "PHPUnit extensions and rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.4.2"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.18"
             },
-            "time": "2024-12-17T17:20:49+00:00"
+            "time": "2026-07-04T12:16:09+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -10947,21 +11053,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "1.2.10",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "40f9cf38c05296bd32f444121336a521a293fa61"
+                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/40f9cf38c05296bd32f444121336a521a293fa61",
-                "reference": "40f9cf38c05296bd32f444121336a521a293fa61",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/b8e68f058bca43e01a2e1caa51ef022d6551ed95",
+                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0",
-                "phpstan/phpstan": "^1.12.5"
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.2.6"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -10986,6 +11092,7 @@
                 "MIT"
             ],
             "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
             "keywords": [
                 "automation",
                 "dev",
@@ -10994,7 +11101,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/1.2.10"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.1"
             },
             "funding": [
                 {
@@ -11002,7 +11109,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-11-08T13:59:10+00:00"
+            "time": "2026-08-03T17:30:34+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -111,11 +111,6 @@ parameters:
 			path: web/modules/custom/simplytest_launch/tests/src/Kernel/TypedData/InstanceLaunchDefinitionTest.php
 
 		-
-			message: "#^Class Drupal\\\\simplytest_ocd\\\\OneClickDemoPluginManager referenced with incorrect case\\: Drupal\\\\simplytest_ocd\\\\OneCLickDemoPluginManager\\.$#"
-			count: 2
-			path: web/modules/custom/simplytest_ocd/src/Controller/Resources.php
-
-		-
 			message: "#^Method Drupal\\\\simplytest_ocd\\\\Controller\\\\Resources\\:\\:create\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/custom/simplytest_ocd/src/Controller/Resources.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,6 +9,13 @@ parameters:
 		entityMapping:
 			simplytest_project:
 				class: Drupal\simplytest_projects\Entity\SimplytestProject
+	ignoreErrors:
+		# EntityListBuilder::createInstance() hands the storage to the
+		# constructor, so a list builder cannot take the entity type manager
+		# instead without breaking core's own contract.
+		-
+			identifier: drupal.entityStorageDirectInjection
+			path: web/modules/custom/simplytest_projects/src/SimplytestProjectListBuilder.php
 includes:
 	- phpstan-baseline.neon
 	- vendor/phpstan/phpstan/conf/bleedingEdge.neon

--- a/rector.php
+++ b/rector.php
@@ -2,12 +2,31 @@
 
 declare(strict_types=1);
 
+use DrupalRector\Set\DrupalSetProvider;
 use Rector\Config\RectorConfig;
 
 return RectorConfig::configure()
     ->withPaths([
-        __DIR__ . '/drush',
+        // No `drush/`: everything under it is composer-installed contrib, and
+        // our own Drush commands live in the modules.
         __DIR__ . '/web/modules/custom',
+        __DIR__ . '/web/profiles/simplytest',
+        __DIR__ . '/web/themes/simplytest_theme',
     ])
+    // Reads the installed drupal/core and phpunit/phpunit versions and loads
+    // only the sets that apply to them, so the rules track a dependency bump
+    // instead of a hand-maintained version list. The Drupal group also brings
+    // the bootstrap that turns off DeprecationHelper wrapping and teaches
+    // Rector about .module, .install, .profile and .theme files.
+    ->withSetProviders(DrupalSetProvider::class)
+    ->withComposerBased(drupal: true, phpunit: true)
+    // Annotations that carry no value (@group, @test). The ones that do
+    // (@covers, @dataProvider, @depends) come from the composer-based set,
+    // which knows which PHPUnit version added each attribute.
+    ->withAttributesSets(phpunit: true)
     ->withPhpSets()
-    ->withTypeCoverageLevel(0);
+    ->withTypeCoverageLevel(0)
+    // Drupal's coding standards want a `use` statement rather than a
+    // fully-qualified name inline, which is how Rector writes attributes
+    // otherwise. Doc blocks keep their fully-qualified type hints.
+    ->withImportNames(importDocBlockNames: false, importShortClasses: false);

--- a/web/modules/custom/simplytest_launch/tests/src/Kernel/LaunchControllerTest.php
+++ b/web/modules/custom/simplytest_launch/tests/src/Kernel/LaunchControllerTest.php
@@ -122,12 +122,14 @@ final class LaunchControllerTest extends KernelTestBase {
       ->execute();
 
     $version_manager = $this->container->get('simplytest_projects.project_version_manager');
-    self::assertEmpty($version_manager->getAllReleases('token'));
+    $before = $version_manager->getAllReleases('token');
+    self::assertEmpty($before);
 
     $response = $this->handle($this->selectorRequest('token', '8.x-1.9'));
 
     self::assertEquals(302, $response->getStatusCode());
-    self::assertNotEmpty($version_manager->getAllReleases('token'));
+    $after = $version_manager->getAllReleases('token');
+    self::assertNotEmpty($after);
   }
 
   /**

--- a/web/modules/custom/simplytest_ocd/src/Controller/Resources.php
+++ b/web/modules/custom/simplytest_ocd/src/Controller/Resources.php
@@ -5,7 +5,7 @@ namespace Drupal\simplytest_ocd\Controller;
 use Drupal\Core\Cache\CacheableJsonResponse;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Url;
-use Drupal\simplytest_ocd\OneCLickDemoPluginManager;
+use Drupal\simplytest_ocd\OneClickDemoPluginManager;
 use Drupal\simplytest_tugboat\InstanceManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;

--- a/web/modules/custom/simplytest_projects/src/Plugin/QueueWorker/ProjectRefresher.php
+++ b/web/modules/custom/simplytest_projects/src/Plugin/QueueWorker/ProjectRefresher.php
@@ -41,10 +41,13 @@ class ProjectRefresher extends QueueWorkerBase implements ContainerFactoryPlugin
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    private readonly EntityTypeManagerInterface $entityTypeManager,
-    private readonly ProjectVersionManager $projectVersionManager,
-    private readonly LoggerInterface $logger,
-    private readonly TimeInterface $time,
+    // Not private and not readonly: DependencySerializationTrait, which
+    // QueueWorkerBase inherits, rehydrates these by reflection when the queue
+    // item is unserialized, and it can do neither on PHP 8.3.
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected ProjectVersionManager $projectVersionManager,
+    protected LoggerInterface $logger,
+    protected TimeInterface $time,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }

--- a/web/modules/custom/simplytest_projects/src/ProjectFetcher.php
+++ b/web/modules/custom/simplytest_projects/src/ProjectFetcher.php
@@ -321,10 +321,16 @@ class ProjectFetcher {
 
     $results = $query->execute()->fetchAll();
 
+    // Built key by key rather than cast wholesale: the query also selects
+    // `sandbox` and the `rank` expression, which order the results but are not
+    // part of what callers get.
     $projects = [];
     foreach ($results as $result) {
-      unset($result->sandbox, $result->rank);
-      $projects[] = (array) $result;
+      $projects[] = [
+        'title' => (string) $result->title,
+        'shortname' => (string) $result->shortname,
+        'type' => (string) $result->type,
+      ];
     }
 
     return $projects;

--- a/web/modules/custom/simplytest_projects/src/ReleaseHistory/Processor.php
+++ b/web/modules/custom/simplytest_projects/src/ReleaseHistory/Processor.php
@@ -74,16 +74,25 @@ final class Processor {
           $release_data['core_compatibility'] = '8.x';
         }
 
-        $release_data['terms'] = [];
+        $terms = [];
         if ($release->terms) {
           foreach ($release->terms->children() as $term) {
-            if (!isset($release_data['terms'][(string) $term->name])) {
-              $release_data['terms'][(string) $term->name] = [];
-            }
-            $release_data['terms'][(string) $term->name][] = (string) $term->value;
+            $terms[(string) $term->name][] = (string) $term->value;
           }
         }
-        $data['releases'][$version] = new ProjectRelease($release_data);
+
+        // Built key by key rather than handed the whole parsed node: a release
+        // element carries plenty that nothing here reads, and this is the shape
+        // ProjectRelease documents.
+        $data['releases'][$version] = new ProjectRelease([
+          'name' => $release_data['name'] ?? '',
+          'core_compatibility' => $release_data['core_compatibility'],
+          'version' => $version,
+          'tag' => $release_data['tag'],
+          'date' => $release_data['date'],
+          'status' => $release_data['status'] ?? '',
+          'terms' => $terms,
+        ]);
       }
     }
     return $data;

--- a/web/modules/custom/simplytest_projects/src/ReleaseHistory/ProjectRelease.php
+++ b/web/modules/custom/simplytest_projects/src/ReleaseHistory/ProjectRelease.php
@@ -12,7 +12,10 @@ use Composer\Semver\Semver;
  * @property string $date
  * @property string $status
  *
- * @phpstan-type ReleaseTerms array{"Release type": list<string>}
+ * The release XML carries whatever terms Drupal.org has on the release, so
+ * the map is open; only "Release type" is ever read.
+ *
+ * @phpstan-type ReleaseTerms array<string, list<string>>
  * @phpstan-type ReleaseData array{name: string, core_compatibility: string, version: string, tag: string, date: string, status: string, terms: ReleaseTerms}
  */
 final class ProjectRelease {

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectHooksTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectHooksTest.php
@@ -100,11 +100,13 @@ final class ProjectHooksTest extends KernelTestBase {
    */
   public function testProjectInsertFetchesReleases(): void {
     $version_manager = $this->container->get('simplytest_projects.project_version_manager');
-    self::assertEmpty($version_manager->getAllReleases('token'));
+    $before = $version_manager->getAllReleases('token');
+    self::assertEmpty($before);
 
     $this->createProject('token');
 
-    self::assertNotEmpty($version_manager->getAllReleases('token'));
+    $after = $version_manager->getAllReleases('token');
+    self::assertNotEmpty($after);
   }
 
   /**

--- a/web/modules/custom/simplytest_tugboat/src/InstanceManager.php
+++ b/web/modules/custom/simplytest_tugboat/src/InstanceManager.php
@@ -142,11 +142,14 @@ class InstanceManager implements InstanceManagerInterface {
       // Send parameters.
       $parameters  = [
         'perform_install' => !$submission['manualInstall'],
-        'install_profile' => $submission['installProfile'],
-        'drupal_core_version' => $submission['drupalVersion'],
-        'project_type' => $project->type->value,
-        'project_version' => $project_version,
-        'project' => $project->shortname->value,
+        // Cast: the submission arrives as validated typed data and the entity
+        // fields are strings, but neither is typed as such at this point, and
+        // LaunchRecord stores them as strings.
+        'install_profile' => (string) $submission['installProfile'],
+        'drupal_core_version' => (string) $submission['drupalVersion'],
+        'project_type' => (string) $project->type->value,
+        'project_version' => (string) $project_version,
+        'project' => (string) $project->shortname->value,
         'patches' => array_filter($submission['project']['patches'] ?? []),
         // @todo do we need to map the versions at all?
         'additionals' => $additional_projects,

--- a/web/modules/custom/simplytest_tugboat/src/LaunchRecord.php
+++ b/web/modules/custom/simplytest_tugboat/src/LaunchRecord.php
@@ -10,6 +10,23 @@ namespace Drupal\simplytest_tugboat;
  * somebody is testing, which is identifying in a way a bare count is not.
  *
  * @see \Drupal\simplytest_tugboat\LaunchRecorder
+ *
+ * The optional keys are the ones only the preview config generator reads; a
+ * launch record is built from the same array and ignores them.
+ *
+ * @phpstan-type PreviewParameters array{
+ *   project: string,
+ *   project_type: string,
+ *   project_version: string,
+ *   drupal_core_version: string,
+ *   install_profile: string,
+ *   perform_install: bool,
+ *   patches: array<mixed>,
+ *   additionals: array<mixed>,
+ *   instance_id?: string,
+ *   hash?: string,
+ *   major_version?: int,
+ * }
  */
 final readonly class LaunchRecord {
 
@@ -49,16 +66,7 @@ final readonly class LaunchRecord {
   /**
    * Builds a record from the preview parameters of a normal launch.
    *
-   * @param array{
-   *   project: string,
-   *   project_type: string,
-   *   project_version: string,
-   *   drupal_core_version: string,
-   *   install_profile: string,
-   *   perform_install: bool,
-   *   patches: array<mixed>,
-   *   additionals: array<mixed>,
-   * } $parameters
+   * @param PreviewParameters $parameters
    *   The parameters handed to the preview config generator.
    */
   public static function fromPreviewParameters(array $parameters): self {

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchRecorderTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchRecorderTest.php
@@ -13,6 +13,8 @@ use Drupal\simplytest_tugboat\LaunchRecorder;
  * @group simplytest_tugboat
  *
  * @coversDefaultClass \Drupal\simplytest_tugboat\LaunchRecorder
+ *
+ * @phpstan-import-type PreviewParameters from \Drupal\simplytest_tugboat\LaunchRecord
  */
 final class LaunchRecorderTest extends KernelTestBase {
 
@@ -145,7 +147,7 @@ final class LaunchRecorderTest extends KernelTestBase {
   }
 
   /**
-   * @return array<string, mixed>
+   * @return PreviewParameters
    */
   private function previewParameters(): array {
     return [

--- a/web/modules/custom/simplytest_tugboat/tests/src/Unit/TugboatConfigTestBase.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Unit/TugboatConfigTestBase.php
@@ -52,7 +52,7 @@ abstract class TugboatConfigTestBase extends UnitTestCase {
   /**
    * The test data.
    *
-   * @return \Generator
+   * @return \Generator<array-key, array{array<string, mixed>, array<string, mixed>}>
    */
   abstract public static function configData(): \Generator;
 


### PR DESCRIPTION
First of a two-PR stack. This one adds the tool and cleans up what it drags in; [#643](https://github.com/simplytestme/website/pull/643) applies the fixes.

## Why the toolchain moves

`palantirnet/drupal-rector` 1.1 requires Rector `^2`, and Rector 2 requires PHPStan `^2`, so the three move together. `drupal/core-dev` already allowed `phpstan/phpstan: ^1.12.27 || ^2.2.0` — the only things pinning 1.12 were `phpstan-drupal`, `phpstan-deprecation-rules` and `phpstan-phpunit`, all of which have 2.x releases. PHPStan 1.12 had been printing an "old version" banner for over a year, so this was overdue regardless.

## rector.php

Uses composer-based set selection rather than a hand-kept version list:

```php
->withSetProviders(DrupalSetProvider::class)
->withComposerBased(drupal: true, phpunit: true)
->withAttributesSets(phpunit: true)
```

Rector reads the installed `drupal/core` and `phpunit/phpunit` versions and loads only the sets that apply, so the rules follow a dependency bump on their own. (The drupal-rector README says this needs an unreleased Rector; that's stale — it shipped in 2.5 and we're on 2.6.1.)

The Drupal group also carries a bootstrap that turns off `DeprecationHelper` BC wrapping (right for a site pinned to one core version) and teaches Rector about `.module`, `.install`, `.profile` and `.theme` files — which is why the install profile and theme join the scanned paths. `withAttributesSets(phpunit: true)` covers annotations carrying no value (`@group`, `@test`); the ones that do (`@covers`, `@dataProvider`, `@depends`) come from the composer-based set, which knows which PHPUnit version added each attribute.

## The 24 PHPStan errors that surfaced

None are new code — all are things 1.12 couldn't see.

**Fixed properly:**

- **`ProjectRefresher` promoted its injected services as `private readonly`.** `QueueWorkerBase` brings `DependencySerializationTrait`, which rehydrates by reflection when a queue item is unserialized and can do neither on PHP 8.3. Now `protected` and mutable. This is the one that looked like a latent bug rather than a lint nit.
- **`ProjectFetcher::searchFromProjects()`** built rows by casting the whole result object and unsetting two columns. It now builds the three documented keys directly, which is what the return type already claimed.
- **`Processor`** handed the whole parsed release node to `ProjectRelease`. It now passes the seven keys `ProjectRelease` documents; nothing read the rest. `ReleaseTerms` widens from a sealed single-key shape to an open map, because the XML carries whatever terms Drupal.org has and only `Release type` is ever read.
- **`LaunchRecord`'s preview-parameter shape** becomes a `@phpstan-type` the recorder test imports, instead of the test declaring `array<string, mixed>` and losing the shape. The generator's own keys (`instance_id`, `hash`, `major_version`) join it as optional.
- **`InstanceManager`** casts the five values it takes from the submission and the project entity; neither is typed as a string at that point.
- **Two tests** asserted empty then not-empty on the same call expression, which PHPStan reads as always false. They now hold each result in its own variable.
- **`Resources.php` imported `OneCLickDemoPluginManager`** — stray capital L. PHP doesn't care, so a baseline entry had been carrying it. Both are gone.

**One ignore added instead**, in `phpstan.neon` with the reason inline: `EntityListBuilder::createInstance()` hands storage to the constructor, so a list builder can't take the entity type manager instead without breaking core's own contract.

## Verification

- `phpstan` level 6: **no errors**.
- `phpunit`: **286 tests, 937 assertions, green** (4m53s locally).

Rector still reports the PHPUnit attribute migration as pending — that's #643. The Rector CI job is unchanged here (it runs without `--dry-run`, so it doesn't gate); #643 flips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)