### PR TITLE
Migrate tests to PHPUnit attributes, isolate kernel tests [skip deploy]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,8 +175,10 @@ jobs:
             tools: composer:v2
       - name: Install dependencies
         run: composer install
+      # --dry-run so the job reports drift instead of silently rewriting the
+      # runner's checkout and always passing.
       - name: Rector
-        run: vendor/bin/rector
+        run: vendor/bin/rector --dry-run
   phpunit:
     runs-on: ubuntu-latest
     name: phpunit

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -86,11 +86,6 @@ parameters:
 			path: web/modules/custom/simplytest_launch/src/Plugin/Validation/Constraint/PatchesUrlConstraintValidator.php
 
 		-
-			message: "#^Method Drupal\\\\simplytest_launch\\\\Plugin\\\\Validation\\\\Constraint\\\\PatchesUrlConstraintValidator\\:\\:validate\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: web/modules/custom/simplytest_launch/src/Plugin/Validation/Constraint/PatchesUrlConstraintValidator.php
-
-		-
 			message: "#^Method Drupal\\\\simplytest_launch\\\\SimplytestLaunchServiceProvider\\:\\:alter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/custom/simplytest_launch/src/SimplytestLaunchServiceProvider.php
@@ -900,11 +895,6 @@ parameters:
 
 		-
 			message: "#^Method Drupal\\\\Tests\\\\simplytest_tugboat\\\\Unit\\\\InstanceManagerTest\\:\\:testDrupal9WithAdditionals\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: web/modules/custom/simplytest_tugboat/tests/src/Unit/InstanceManagerTest.php
-
-		-
-			message: "#^Method Drupal\\\\Tests\\\\simplytest_tugboat\\\\Unit\\\\InstanceManagerTest\\:\\:testPanopoly\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: web/modules/custom/simplytest_tugboat/tests/src/Unit/InstanceManagerTest.php
 

--- a/web/modules/custom/simplytest_launch/src/Controller/SimplyTestLaunch.php
+++ b/web/modules/custom/simplytest_launch/src/Controller/SimplyTestLaunch.php
@@ -21,7 +21,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
-use Symfony\Component\Validator\ConstraintViolationInterface;
 
 /**
  * Returns responses for config module routes.

--- a/web/modules/custom/simplytest_launch/src/Plugin/Validation/Constraint/PatchesUrlConstraintValidator.php
+++ b/web/modules/custom/simplytest_launch/src/Plugin/Validation/Constraint/PatchesUrlConstraintValidator.php
@@ -36,7 +36,7 @@ final class PatchesUrlConstraintValidator extends UrlValidator implements Contai
    * {@inheritdoc}
    */
   #[\Override]
-  public function validate($value, Constraint $constraint): void {
+  public function validate(mixed $value, Constraint $constraint): void {
     parent::validate($value, $constraint);
     $value = (string) $value;
     if ('' === $value) {

--- a/web/modules/custom/simplytest_launch/tests/src/Kernel/LaunchControllerTest.php
+++ b/web/modules/custom/simplytest_launch/tests/src/Kernel/LaunchControllerTest.php
@@ -9,21 +9,30 @@ use Drupal\Core\Routing\LocalRedirectResponse;
 use Drupal\Core\Url;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_launch\Controller\SimplyTestLaunch;
+use Drupal\simplytest_launch\EventSubscriber\UnprocessableHttpExceptionSubscriber;
+use Drupal\simplytest_launch\Plugin\Validation\Constraint\CoreVersionConstraintValidator;
 use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\simplytest_projects\Entity\SimplytestProject;
 use Drupal\simplytest_projects\ProjectTypes;
 use Drupal\simplytest_projects\ProjectVersionManager;
 use Drupal\simplytest_tugboat\LaunchRecorder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
-/**
- * @group simplytest
- * @group simplytest_launch
- *
- * @coversDefaultClass \Drupal\simplytest_launch\Controller\SimplyTestLaunch
- */
+#[CoversClass(SimplyTestLaunch::class)]
+#[CoversMethod(SimplyTestLaunch::class, 'configure')]
+#[CoversMethod(SimplyTestLaunch::class, 'projectSelector')]
+#[CoversMethod(SimplyTestLaunch::class, 'launchProject')]
+#[CoversMethod(UnprocessableHttpExceptionSubscriber::class, 'on4xx')]
+#[CoversMethod(CoreVersionConstraintValidator::class, 'validate')]
+#[Group('simplytest')]
+#[Group('simplytest_launch')]
+#[RunTestsInSeparateProcesses]
 final class LaunchControllerTest extends KernelTestBase {
 
   protected static $modules = [
@@ -62,9 +71,6 @@ final class LaunchControllerTest extends KernelTestBase {
       ->execute();
   }
 
-  /**
-   * @covers ::configure
-   */
   public function testConfigure(): void {
     $url = Url::fromRoute('simplytest_launch.configure', [], [
       'query' => ['launcher' => 'custom-launcher'],
@@ -77,8 +83,6 @@ final class LaunchControllerTest extends KernelTestBase {
 
   /**
    * A project that is not stored yet is fetched before redirecting.
-   *
-   * @covers ::projectSelector
    */
   public function testProjectSelectorFetchesUnknownProject(): void {
     $response = $this->handleRedirect($this->selectorRequest('token', '8.x-1.9'));
@@ -94,8 +98,6 @@ final class LaunchControllerTest extends KernelTestBase {
 
   /**
    * A branch shorthand is expanded to the matching dev release.
-   *
-   * @covers ::projectSelector
    */
   public function testProjectSelectorExpandsBranchToDev(): void {
     $response = $this->handleRedirect($this->selectorRequest('token', '8.x-1.x'));
@@ -105,8 +107,6 @@ final class LaunchControllerTest extends KernelTestBase {
 
   /**
    * A known project with an unknown release refreshes its release history.
-   *
-   * @covers ::projectSelector
    */
   public function testProjectSelectorRefreshesMissingRelease(): void {
     // Store the project without any release data.
@@ -134,8 +134,6 @@ final class LaunchControllerTest extends KernelTestBase {
 
   /**
    * The redirect carries the cache metadata the launcher depends on.
-   *
-   * @covers ::projectSelector
    */
   public function testProjectSelectorCacheMetadata(): void {
     $this->createProject('token');
@@ -147,8 +145,6 @@ final class LaunchControllerTest extends KernelTestBase {
 
   /**
    * Extra query parameters are carried through to the configure page.
-   *
-   * @covers ::projectSelector
    */
   public function testProjectSelectorForwardsQueryParameters(): void {
     $this->createProject('token');
@@ -162,9 +158,6 @@ final class LaunchControllerTest extends KernelTestBase {
     self::assertStringContainsString('install_profile=umami', urldecode($response->getTargetUrl()));
   }
 
-  /**
-   * @covers ::launchProject
-   */
   public function testLaunchProject(): void {
     $this->createProject('token');
     $this->container->get('simplytest_projects.project_version_manager')->updateData('token');
@@ -190,9 +183,6 @@ final class LaunchControllerTest extends KernelTestBase {
 
   /**
    * Invalid submissions come back as a 422 listing every violation.
-   *
-   * @covers ::launchProject
-   * @covers \Drupal\simplytest_launch\EventSubscriber\UnprocessableHttpExceptionSubscriber::on4xx
    */
   public function testLaunchProjectWithInvalidSubmission(): void {
     $response = $this->handle($this->launchRequest([
@@ -211,8 +201,6 @@ final class LaunchControllerTest extends KernelTestBase {
 
   /**
    * A version that is not a known release is rejected.
-   *
-   * @covers ::launchProject
    */
   public function testLaunchProjectWithUnknownVersion(): void {
     $this->createProject('token');
@@ -240,9 +228,6 @@ final class LaunchControllerTest extends KernelTestBase {
    * The form only offers stored releases, but the endpoint takes any JSON, and
    * the value would otherwise reach the sandbox build and the public
    * statistics untouched.
-   *
-   * @covers ::launchProject
-   * @covers \Drupal\simplytest_launch\Plugin\Validation\Constraint\CoreVersionConstraintValidator::validate
    */
   public function testLaunchProjectWithUnknownCoreVersion(): void {
     $response = $this->handle($this->launchRequest([
@@ -267,8 +252,6 @@ final class LaunchControllerTest extends KernelTestBase {
 
   /**
    * Only the install profiles the form offers may be launched.
-   *
-   * @covers ::launchProject
    */
   public function testLaunchProjectWithUnknownInstallProfile(): void {
     $response = $this->handle($this->launchRequest([
@@ -297,8 +280,6 @@ final class LaunchControllerTest extends KernelTestBase {
    * The controller is called directly rather than through the kernel: a 5xx is
    * logged by core's exception subscriber, and KernelTestBase turns any logged
    * error into a test failure.
-   *
-   * @covers ::launchProject
    */
   public function testLaunchProjectWhenTugboatIsUnreachable(): void {
     $this->createProject('token');
@@ -325,8 +306,6 @@ final class LaunchControllerTest extends KernelTestBase {
 
   /**
    * A submission that is not an array at all is rejected, not fatal.
-   *
-   * @covers ::launchProject
    */
   public function testLaunchProjectWithUnusableSubmission(): void {
     $controller = SimplyTestLaunch::create($this->container);

--- a/web/modules/custom/simplytest_launch/tests/src/Kernel/TypedData/InstanceLaunchDefinitionTest.php
+++ b/web/modules/custom/simplytest_launch/tests/src/Kernel/TypedData/InstanceLaunchDefinitionTest.php
@@ -6,12 +6,14 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_launch\Plugin\DataType\InstanceLaunch;
 use Drupal\simplytest_launch\TypedData\InstanceLaunchDefinition;
 use Drupal\simplytest_projects\CoreVersionManager;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 
-/**
- * @group simplytest
- * @group simplytest_launch
- */
+#[Group('simplytest')]
+#[Group('simplytest_launch')]
+#[RunTestsInSeparateProcesses]
 final class InstanceLaunchDefinitionTest extends KernelTestBase {
 
   protected static $modules = [
@@ -43,9 +45,7 @@ final class InstanceLaunchDefinitionTest extends KernelTestBase {
       ->execute();
   }
 
-  /**
-   * @dataProvider instanceLaunchData
-   */
+  #[DataProvider('instanceLaunchData')]
   public function testValidation(array $data, array $expected_violations) {
     $typed_data_manager = $this->container->get('typed_data_manager');
     $data = $typed_data_manager->create(InstanceLaunchDefinition::create(), $data);

--- a/web/modules/custom/simplytest_ocd/src/Plugin/OneClickDemo/Umami.php
+++ b/web/modules/custom/simplytest_ocd/src/Plugin/OneClickDemo/Umami.php
@@ -4,7 +4,6 @@ namespace Drupal\simplytest_ocd\Plugin\OneClickDemo;
 
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\simplytest_ocd\Attribute\OneClickDemo;
-use Drupal\simplytest_ocd\OneClickDemoInterface;
 
 /**
  * Provides one click demo for umami.

--- a/web/modules/custom/simplytest_ocd/tests/src/Kernel/ResourcesTest.php
+++ b/web/modules/custom/simplytest_ocd/tests/src/Kernel/ResourcesTest.php
@@ -12,16 +12,21 @@ use Drupal\simplytest_ocd\Controller\Resources;
 use Drupal\simplytest_ocd\OneClickDemoPluginManager;
 use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\simplytest_projects\ProjectVersionManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
-/**
- * @group simplytest
- * @group simplytest_ocd
- *
- * @coversDefaultClass \Drupal\simplytest_ocd\Controller\Resources
- */
+#[CoversClass(Resources::class)]
+#[CoversMethod(Resources::class, 'info')]
+#[CoversMethod(Resources::class, 'launch')]
+#[CoversMethod(OneClickDemoPluginManager::class, '__construct')]
+#[Group('simplytest')]
+#[Group('simplytest_ocd')]
+#[RunTestsInSeparateProcesses]
 final class ResourcesTest extends KernelTestBase {
 
   protected static $modules = [
@@ -44,9 +49,6 @@ final class ResourcesTest extends KernelTestBase {
       ->save();
   }
 
-  /**
-   * @covers ::info
-   */
   public function testInfoListsEveryDemo(): void {
     $url = Url::fromRoute('simplytest_ocd.ocd');
     $request = Request::create($url->toString(), 'GET');
@@ -77,8 +79,6 @@ final class ResourcesTest extends KernelTestBase {
 
   /**
    * The response is invalidated when the plugin definitions change.
-   *
-   * @covers ::info
    */
   public function testInfoIsCacheable(): void {
     $response = Resources::create($this->container)->info();
@@ -87,9 +87,6 @@ final class ResourcesTest extends KernelTestBase {
     self::assertContains('oneclickdemo', $response->getCacheableMetadata()->getCacheTags());
   }
 
-  /**
-   * @covers ::launch
-   */
   public function testLaunch(): void {
     $response = Resources::create($this->container)->launch('oneclickdemo_umami');
 
@@ -103,18 +100,12 @@ final class ResourcesTest extends KernelTestBase {
     self::assertEquals('simplytest', $payload['name']);
   }
 
-  /**
-   * @covers ::launch
-   */
   public function testLaunchRejectsUnknownDemo(): void {
     $this->expectException(NotFoundHttpException::class);
     $this->expectExceptionMessage('nope is not a valid option');
     Resources::create($this->container)->launch('nope');
   }
 
-  /**
-   * @covers ::launch
-   */
   public function testLaunchWhenTugboatIsUnreachable(): void {
     $this->config('tugboat.settings')->set('repository_id', 'brokenrepo')->save();
 
@@ -122,9 +113,6 @@ final class ResourcesTest extends KernelTestBase {
     Resources::create($this->container)->launch('oneclickdemo_umami');
   }
 
-  /**
-   * @covers \Drupal\simplytest_ocd\OneClickDemoPluginManager::__construct
-   */
   public function testPluginManagerDefinitions(): void {
     $manager = $this->container->get('plugin.manager.oneclickdemo');
 

--- a/web/modules/custom/simplytest_projects/src/ReleaseHistory/Fetcher.php
+++ b/web/modules/custom/simplytest_projects/src/ReleaseHistory/Fetcher.php
@@ -7,7 +7,6 @@ use Drupal\Core\State\StateInterface;
 use Drupal\simplytest_projects\Exception\ReleaseHistoryNotModifiedException;
 use Drupal\update\UpdateFetcher;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Psr7\Request;
 
 /**
  * Fetches release history.

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/ControllerTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/ControllerTest.php
@@ -9,8 +9,10 @@ use Drupal\Core\DependencyInjection\ServiceModifierInterface;
 use Drupal\Core\Url;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_projects\CoreVersionManager;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Request;
 
+#[RunTestsInSeparateProcesses]
 final class ControllerTest extends KernelTestBase implements ServiceModifierInterface {
 
   protected static $modules = [

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/CoreVersionManagerTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/CoreVersionManagerTest.php
@@ -8,14 +8,20 @@ use Drupal\simplytest_projects\CoreVersionManager;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Psr\Http\Message\RequestInterface;
 
-/**
- * @group simplytest
- * @group simplytest_project
- *
- * @coversDefaultClass \Drupal\simplytest_projects\CoreVersionManager
- */
+#[CoversClass(CoreVersionManager::class)]
+#[CoversMethod(CoreVersionManager::class, 'updateData')]
+#[CoversMethod(CoreVersionManager::class, 'hasVersion')]
+#[CoversMethod(CoreVersionManager::class, 'getVersions')]
+#[Group('simplytest')]
+#[Group('simplytest_project')]
+#[RunTestsInSeparateProcesses]
 final class CoreVersionManagerTest extends KernelTestBase {
 
   protected static $modules = [
@@ -38,6 +44,7 @@ final class CoreVersionManagerTest extends KernelTestBase {
     $this->sut = $this->container->get('simplytest_projects.core_version_manager');
   }
 
+  #[\Override]
   public function register(ContainerBuilder $container): void {
     parent::register($container);
     $container->register(self::class, self::class)
@@ -66,8 +73,6 @@ final class CoreVersionManagerTest extends KernelTestBase {
 
   /**
    * Core release data comes from updates.drupal.org, conditionally.
-   *
-   * @covers ::updateData
    */
   public function testConditionalRequests(): void {
     $this->sut->updateData(8);
@@ -89,9 +94,6 @@ final class CoreVersionManagerTest extends KernelTestBase {
     );
   }
 
-  /**
-   * @covers ::hasVersion
-   */
   public function testHasVersion(): void {
     self::assertFalse($this->sut->hasVersion('11.2.3'));
 
@@ -103,9 +105,6 @@ final class CoreVersionManagerTest extends KernelTestBase {
   }
 
   /**
-   * @dataProvider coreVersionData
-   * @covers ::updateData
-   * @covers ::getVersions
    *
    * @param int $major_version
    *   The test major version.
@@ -116,6 +115,7 @@ final class CoreVersionManagerTest extends KernelTestBase {
    *
    * @throws \Exception
    */
+  #[DataProvider('coreVersionData')]
   public function testReleaseData(int $major_version, int $expected_count, array $expected_result_sample): void {
     $this->sut->updateData($major_version);
     $results = $this->sut->getVersions($major_version);

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectCommandsTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectCommandsTest.php
@@ -8,13 +8,18 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_projects\Commands\SimplytestProjectsCommands;
 use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\simplytest_projects\ProjectVersionManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
-/**
- * @group simplytest
- * @group simplytest_project
- *
- * @coversDefaultClass \Drupal\simplytest_projects\Commands\SimplytestProjectsCommands
- */
+#[CoversClass(SimplytestProjectsCommands::class)]
+#[CoversMethod(SimplytestProjectsCommands::class, 'coreVersionsUpdate')]
+#[CoversMethod(SimplytestProjectsCommands::class, 'getReleaseData')]
+#[CoversMethod(SimplytestProjectsCommands::class, 'importProject')]
+#[Group('simplytest')]
+#[Group('simplytest_project')]
+#[RunTestsInSeparateProcesses]
 final class ProjectCommandsTest extends KernelTestBase {
 
   protected static $modules = [
@@ -39,9 +44,6 @@ final class ProjectCommandsTest extends KernelTestBase {
     );
   }
 
-  /**
-   * @covers ::coreVersionsUpdate
-   */
   public function testCoreVersionsUpdate(): void {
     $this->sut->coreVersionsUpdate('9');
 
@@ -50,9 +52,6 @@ final class ProjectCommandsTest extends KernelTestBase {
     );
   }
 
-  /**
-   * @covers ::getReleaseData
-   */
   public function testGetReleaseData(): void {
     $this->sut->getReleaseData('token');
 
@@ -61,9 +60,6 @@ final class ProjectCommandsTest extends KernelTestBase {
     );
   }
 
-  /**
-   * @covers ::importProject
-   */
   public function testImportProject(): void {
     $this->sut->importProject('token');
 

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectFetcherTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectFetcherTest.php
@@ -12,14 +12,20 @@ use Drupal\simplytest_projects\ProjectFetcher;
 use Drupal\simplytest_projects\ProjectTypes;
 use Drupal\simplytest_projects\ProjectVersionManager;
 use Drupal\simplytest_projects_test\TestDatabaseLockBackend;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * @group simplytest
- * @group simplytest_project
- *
- * @coversDefaultClass \Drupal\simplytest_projects\ProjectFetcher
- */
+#[CoversClass(ProjectFetcher::class)]
+#[CoversMethod(ProjectFetcher::class, 'fetchProject')]
+#[CoversMethod(ProjectFetcher::class, 'fetchVersions')]
+#[CoversMethod(ProjectFetcher::class, 'searchFromProjects')]
+#[Group('simplytest')]
+#[Group('simplytest_project')]
+#[RunTestsInSeparateProcesses]
 final class ProjectFetcherTest extends KernelTestBase {
 
   protected static $modules = [
@@ -37,6 +43,7 @@ final class ProjectFetcherTest extends KernelTestBase {
     $this->sut = $this->container->get('simplytest_projects.fetcher');
   }
 
+  #[\Override]
   public function register(ContainerBuilder $container): void {
     parent::register($container);
     $container
@@ -65,9 +72,6 @@ final class ProjectFetcherTest extends KernelTestBase {
     self::assertNotNull($result);
   }
 
-  /**
-   * @covers ::fetchProject
-   */
   public function testFetchProjectIsCaseInsensitive(): void {
     $result = $this->sut->fetchProject('ToKeN');
     self::assertNotNull($result);
@@ -76,8 +80,6 @@ final class ProjectFetcherTest extends KernelTestBase {
 
   /**
    * A second process holding the lock must not double up the work.
-   *
-   * @covers ::fetchProject
    */
   public function testFetchProjectReturnsNullWhenLockIsHeld(): void {
     $lock = $this->container->get('lock');
@@ -92,8 +94,6 @@ final class ProjectFetcherTest extends KernelTestBase {
 
   /**
    * The response body is cached, so a repeat fetch makes no second request.
-   *
-   * @covers ::fetchProject
    */
   public function testFetchProjectUsesCache(): void {
     $this->sut->fetchProject('token');
@@ -110,9 +110,6 @@ final class ProjectFetcherTest extends KernelTestBase {
     self::assertCount(1, $this->projectIds('token'));
   }
 
-  /**
-   * @covers ::fetchProject
-   */
   public function testFetchSandboxProject(): void {
     $result = $this->sut->fetchProject('sandboxed');
     self::assertNotNull($result);
@@ -120,11 +117,7 @@ final class ProjectFetcherTest extends KernelTestBase {
     self::assertEquals('someuser', $result['creator']);
   }
 
-  /**
-   * @dataProvider unfetchableProjects
-   *
-   * @covers ::fetchProject
-   */
+  #[DataProvider('unfetchableProjects')]
   public function testFetchProjectFailure(string $shortname): void {
     self::assertNull($this->sut->fetchProject($shortname));
     self::assertCount(0, $this->projectIds($shortname));
@@ -149,8 +142,6 @@ final class ProjectFetcherTest extends KernelTestBase {
 
   /**
    * Characters that are invalid in a lock key do not stop the fetch.
-   *
-   * @covers ::fetchProject
    */
   public function testFetchProjectSanitizesLockKey(): void {
     $result = $this->sut->fetchProject('not.a-project');
@@ -160,9 +151,6 @@ final class ProjectFetcherTest extends KernelTestBase {
     self::assertTrue($this->container->get('lock')->lockMayBeAvailable('fetch_project_not_a_project'));
   }
 
-  /**
-   * @covers ::fetchVersions
-   */
   public function testFetchVersionsWithoutForce(): void {
     $this->container->get('simplytest_projects.project_version_manager')->updateData('token');
     $versions = $this->sut->fetchVersions('token');
@@ -170,17 +158,12 @@ final class ProjectFetcherTest extends KernelTestBase {
     self::assertContains('8.x-1.9', array_map(static fn(\stdClass $row) => $row->version, $versions));
   }
 
-  /**
-   * @covers ::fetchVersions
-   */
   public function testForcedFetchVersionsForUnknownProject(): void {
     self::assertFalse($this->sut->fetchVersions('notaproject', TRUE));
   }
 
   /**
    * A project refreshed within the last six hours is left alone.
-   *
-   * @covers ::fetchVersions
    */
   public function testForcedFetchVersionsSkipsFreshProject(): void {
     $project = $this->createProject('token');
@@ -196,8 +179,6 @@ final class ProjectFetcherTest extends KernelTestBase {
 
   /**
    * A stale project is refreshed and stamped with the current request time.
-   *
-   * @covers ::fetchVersions
    */
   public function testForcedFetchVersionsRefreshesStaleProject(): void {
     $project = $this->createProject('pathauto');
@@ -217,9 +198,6 @@ final class ProjectFetcherTest extends KernelTestBase {
     self::assertGreaterThan($stale, $storage->load($project->id())->getTimestamp());
   }
 
-  /**
-   * @covers ::searchFromProjects
-   */
   public function testSearchFromProjects(): void {
     $this->createProject('token', 'Token', ProjectTypes::MODULE, usage: 500);
     $this->createProject('pathauto', 'Pathauto', ProjectTypes::MODULE, usage: 900);
@@ -241,8 +219,6 @@ final class ProjectFetcherTest extends KernelTestBase {
 
   /**
    * The project actually asked for outranks more popular partial matches.
-   *
-   * @covers ::searchFromProjects
    */
   public function testSearchRanksExactMatchFirst(): void {
     $this->createProject('ai_provider_openai', 'OpenAI Provider', usage: 900);
@@ -265,8 +241,6 @@ final class ProjectFetcherTest extends KernelTestBase {
 
   /**
    * A search typed like a title still finds the shortname.
-   *
-   * @covers ::searchFromProjects
    */
   public function testSearchNormalizesShortname(): void {
     $this->createProject('menu_link_attributes', 'Menu Link Attributes', usage: 900);
@@ -281,9 +255,6 @@ final class ProjectFetcherTest extends KernelTestBase {
     }
   }
 
-  /**
-   * @covers ::searchFromProjects
-   */
   public function testSearchFromProjectsFiltersByType(): void {
     $this->createProject('token', 'Token', ProjectTypes::MODULE);
     $this->createProject('bootstrap', 'Bootstrap', ProjectTypes::THEME);
@@ -295,9 +266,6 @@ final class ProjectFetcherTest extends KernelTestBase {
     self::assertCount(2, $results);
   }
 
-  /**
-   * @covers ::searchFromProjects
-   */
   public function testSearchFromProjectsRespectsRange(): void {
     $this->createProject('token', 'Token', ProjectTypes::MODULE, usage: 500);
     $this->createProject('pathauto', 'Pathauto', ProjectTypes::MODULE, usage: 900);
@@ -305,9 +273,6 @@ final class ProjectFetcherTest extends KernelTestBase {
     self::assertCount(1, $this->sut->searchFromProjects('o', 1));
   }
 
-  /**
-   * @covers ::searchFromProjects
-   */
   public function testSearchEscapesLikeWildcards(): void {
     $this->createProject('token', 'Token', ProjectTypes::MODULE);
 
@@ -321,8 +286,6 @@ final class ProjectFetcherTest extends KernelTestBase {
    * Two lookups for the same project can race; whichever loses the save must
    * still tell its caller the project exists, and must not disturb the row
    * the winner created.
-   *
-   * @covers ::fetchProject
    */
   public function testFetchProjectDuplicateKeepsOriginal(): void {
     self::assertNotNull($this->sut->fetchProject('token'));

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectFormsTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectFormsTest.php
@@ -11,13 +11,24 @@ use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\simplytest_projects\Entity\SimplytestProject;
 use Drupal\simplytest_projects\Form\ImportForm;
 use Drupal\simplytest_projects\Form\Settings;
+use Drupal\simplytest_projects\Form\SimplytestProjectEntityForm;
 use Drupal\simplytest_projects\ProjectTypes;
 use Drupal\simplytest_projects\ProjectVersionManager;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
-/**
- * @group simplytest
- * @group simplytest_project
- */
+#[CoversMethod(Settings::class, 'buildForm')]
+#[CoversMethod(Settings::class, 'getFormId')]
+#[CoversMethod(Settings::class, 'submitForm')]
+#[CoversMethod(Settings::class, 'validateForm')]
+#[CoversMethod(ImportForm::class, 'buildForm')]
+#[CoversMethod(ImportForm::class, 'getFormId')]
+#[CoversMethod(ImportForm::class, 'submitForm')]
+#[CoversMethod(SimplytestProjectEntityForm::class, 'save')]
+#[Group('simplytest')]
+#[Group('simplytest_project')]
+#[RunTestsInSeparateProcesses]
 final class ProjectFormsTest extends KernelTestBase {
 
   protected static $modules = [
@@ -36,10 +47,6 @@ final class ProjectFormsTest extends KernelTestBase {
     $this->installConfig(['simplytest_projects']);
   }
 
-  /**
-   * @covers \Drupal\simplytest_projects\Form\Settings::buildForm
-   * @covers \Drupal\simplytest_projects\Form\Settings::getFormId
-   */
   public function testSettingsFormBuild(): void {
     $this->config('simplytest_projects.settings')
       ->set('version_timeout', '-2 hour')
@@ -58,9 +65,6 @@ final class ProjectFormsTest extends KernelTestBase {
 
   /**
    * Blank lines and stray whitespace are trimmed out of the blacklists.
-   *
-   * @covers \Drupal\simplytest_projects\Form\Settings::submitForm
-   * @covers \Drupal\simplytest_projects\Form\Settings::validateForm
    */
   public function testSettingsFormSubmit(): void {
     $form_state = new FormState();
@@ -77,10 +81,6 @@ final class ProjectFormsTest extends KernelTestBase {
     self::assertEquals(['^1\\.'], array_values($config->get('blacklisted_versions')));
   }
 
-  /**
-   * @covers \Drupal\simplytest_projects\Form\ImportForm::buildForm
-   * @covers \Drupal\simplytest_projects\Form\ImportForm::getFormId
-   */
   public function testImportFormBuild(): void {
     $form_object = ImportForm::create($this->container);
     self::assertEquals('simplytest_import_form', $form_object->getFormId());
@@ -94,8 +94,6 @@ final class ProjectFormsTest extends KernelTestBase {
 
   /**
    * Submitting the import form seeds Drupal core and queues a batch.
-   *
-   * @covers \Drupal\simplytest_projects\Form\ImportForm::submitForm
    */
   public function testImportFormSubmit(): void {
     $form_object = ImportForm::create($this->container);
@@ -121,8 +119,6 @@ final class ProjectFormsTest extends KernelTestBase {
 
   /**
    * A project type the importer rejects is surfaced as a form error message.
-   *
-   * @covers \Drupal\simplytest_projects\Form\ImportForm::submitForm
    */
   public function testImportFormSubmitWithUnsupportedType(): void {
     SimplytestProject::create([
@@ -144,9 +140,6 @@ final class ProjectFormsTest extends KernelTestBase {
     self::assertEquals("The type 'widget' is not allowed.", (string) $messages[0]);
   }
 
-  /**
-   * @covers \Drupal\simplytest_projects\Form\SimplytestProjectEntityForm::save
-   */
   public function testEntityFormSave(): void {
     $project = SimplytestProject::create([
       'title' => 'Token',
@@ -172,9 +165,6 @@ final class ProjectFormsTest extends KernelTestBase {
     );
   }
 
-  /**
-   * @covers \Drupal\simplytest_projects\Form\SimplytestProjectEntityForm::save
-   */
   public function testEntityFormSaveExisting(): void {
     $project = SimplytestProject::create([
       'title' => 'Token',

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectHooksTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectHooksTest.php
@@ -7,7 +7,6 @@ namespace Drupal\Tests\simplytest_projects\Kernel;
 use Drupal\Core\Cache\CacheableResponse;
 use Drupal\Core\EventSubscriber\FinishResponseSubscriber;
 use Drupal\Core\Routing\RouteObjectInterface;
-use Drupal\Core\Url;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\simplytest_projects\Entity\SimplytestProject;
@@ -15,6 +14,10 @@ use Drupal\simplytest_projects\EventSubscriber\ModifyMaxAgeResponseSubscriber;
 use Drupal\simplytest_projects\ProjectTypes;
 use Drupal\simplytest_projects\ProjectVersionManager;
 use Drupal\simplytest_projects\SimplytestProjectListBuilder;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
@@ -23,10 +26,14 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * Covers the module's procedural hooks and its entity list builder.
- *
- * @group simplytest
- * @group simplytest_project
  */
+#[CoversMethod(SimplytestProjectListBuilder::class, 'buildHeader')]
+#[CoversMethod(SimplytestProjectListBuilder::class, 'buildRow')]
+#[CoversMethod(ModifyMaxAgeResponseSubscriber::class, 'getSubscribedEvents')]
+#[CoversMethod(ModifyMaxAgeResponseSubscriber::class, 'onResponse')]
+#[Group('simplytest')]
+#[Group('simplytest_project')]
+#[RunTestsInSeparateProcesses]
 final class ProjectHooksTest extends KernelTestBase {
 
   protected static $modules = [
@@ -109,10 +116,6 @@ final class ProjectHooksTest extends KernelTestBase {
     self::assertNotEmpty($after);
   }
 
-  /**
-   * @covers \Drupal\simplytest_projects\SimplytestProjectListBuilder::buildHeader
-   * @covers \Drupal\simplytest_projects\SimplytestProjectListBuilder::buildRow
-   */
   public function testListBuilder(): void {
     $project = $this->createProject('token');
 
@@ -140,8 +143,6 @@ final class ProjectHooksTest extends KernelTestBase {
    * Core's FinishResponseSubscriber rebuilds the header from scratch at
    * priority 0, and http_cache_control adds s-maxage at -10. A subscriber that
    * runs before either of them has its work thrown away.
-   *
-   * @covers \Drupal\simplytest_projects\EventSubscriber\ModifyMaxAgeResponseSubscriber::getSubscribedEvents
    */
   public function testSubscriberRunsAfterCoreCacheControl(): void {
     $call_order = [];
@@ -156,9 +157,6 @@ final class ProjectHooksTest extends KernelTestBase {
     self::assertGreaterThan($core, $ours);
   }
 
-  /**
-   * @covers \Drupal\simplytest_projects\EventSubscriber\ModifyMaxAgeResponseSubscriber::onResponse
-   */
   public function testMaxAgeIsShortenedOnProjectRoutes(): void {
     $response = self::publicResponse();
     $this->dispatchResponse($response, 'simplytest_projects.core_versions');
@@ -178,8 +176,6 @@ final class ProjectHooksTest extends KernelTestBase {
    * 0, before this subscriber runs, and Fastly prefers that header over
    * s-maxage. Left alone, the edge would keep these routes for the site-wide
    * 32 days.
-   *
-   * @covers \Drupal\simplytest_projects\EventSubscriber\ModifyMaxAgeResponseSubscriber::onResponse
    */
   public function testSurrogateControlIsCappedForTheCdn(): void {
     $response = self::publicResponse();
@@ -193,11 +189,7 @@ final class ProjectHooksTest extends KernelTestBase {
     );
   }
 
-  /**
-   * @dataProvider untouchedResponses
-   *
-   * @covers \Drupal\simplytest_projects\EventSubscriber\ModifyMaxAgeResponseSubscriber::onResponse
-   */
+  #[DataProvider('untouchedResponses')]
   public function testMaxAgeIsUntouched(Response $response, string $route_name, int $request_type): void {
     $before = self::maxAge($response);
     $this->dispatchResponse($response, $route_name, $request_type);

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectImporterTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectImporterTest.php
@@ -4,20 +4,26 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\simplytest_projects\Kernel;
 
-use Drupal\Core\Batch\BatchBuilder;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\simplytest_projects\Entity\SimplytestProject;
 use Drupal\simplytest_projects\ProjectImporter;
 use Drupal\simplytest_projects\ProjectTypes;
 use Drupal\simplytest_projects\ProjectVersionManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
-/**
- * @group simplytest
- * @group simplytest_project
- *
- * @coversDefaultClass \Drupal\simplytest_projects\ProjectImporter
- */
+#[CoversClass(ProjectImporter::class)]
+#[CoversMethod(ProjectImporter::class, 'fetchData')]
+#[CoversMethod(ProjectImporter::class, 'filterExistingProjects')]
+#[CoversMethod(ProjectImporter::class, 'buildBatch')]
+#[CoversMethod(ProjectImporter::class, 'batchProcess')]
+#[CoversMethod(ProjectImporter::class, 'batchFinished')]
+#[Group('simplytest')]
+#[Group('simplytest_project')]
+#[RunTestsInSeparateProcesses]
 final class ProjectImporterTest extends KernelTestBase {
 
   protected static $modules = [
@@ -35,9 +41,6 @@ final class ProjectImporterTest extends KernelTestBase {
     $this->sut = $this->container->get('simplytest_projects.importer');
   }
 
-  /**
-   * @covers ::fetchData
-   */
   public function testFetchData(): void {
     $items = $this->sut->fetchData('project_module');
     self::assertIsArray($items);
@@ -45,26 +48,17 @@ final class ProjectImporterTest extends KernelTestBase {
     self::assertEquals('module_0_1', $items['list'][0]['field_project_machine_name']);
   }
 
-  /**
-   * @covers ::fetchData
-   */
   public function testFetchDataAcceptsAPage(): void {
     $items = $this->sut->fetchData('project_theme', 2);
     self::assertEquals('theme_2_1', $items['list'][0]['field_project_machine_name']);
   }
 
-  /**
-   * @covers ::fetchData
-   */
   public function testFetchDataRejectsUnknownType(): void {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage("The type 'project_nope' is not allowed");
     $this->sut->fetchData('project_nope');
   }
 
-  /**
-   * @covers ::filterExistingProjects
-   */
   public function testFilterExistingProjects(): void {
     SimplytestProject::create([
       'title' => 'Module 0 1',
@@ -87,9 +81,6 @@ final class ProjectImporterTest extends KernelTestBase {
     ], $data[0]);
   }
 
-  /**
-   * @covers ::filterExistingProjects
-   */
   public function testFilterExistingProjectsHandlesSandboxAndMissingAuthor(): void {
     $data = $this->sut->filterExistingProjects([
       [
@@ -105,9 +96,6 @@ final class ProjectImporterTest extends KernelTestBase {
     self::assertEquals('', $data[0]['creator']);
   }
 
-  /**
-   * @covers ::buildBatch
-   */
   public function testBuildBatch(): void {
     $batch = $this->sut->buildBatch('module');
 
@@ -119,18 +107,12 @@ final class ProjectImporterTest extends KernelTestBase {
     self::assertEquals('Importing 3 pages of module', (string) $array['title']);
   }
 
-  /**
-   * @covers ::buildBatch
-   */
   public function testBuildBatchRejectsUnknownType(): void {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage("The type 'widget' is not allowed.");
     $this->sut->buildBatch('widget');
   }
 
-  /**
-   * @covers ::batchProcess
-   */
   public function testBatchProcess(): void {
     // The Batch API hands operations an empty context; batchProcess has to
     // initialize its own counter.
@@ -146,8 +128,6 @@ final class ProjectImporterTest extends KernelTestBase {
 
   /**
    * A project that is already stored does not stop the rest of the batch.
-   *
-   * @covers ::batchProcess
    */
   public function testBatchProcessToleratesDuplicates(): void {
     $context = [];
@@ -158,9 +138,6 @@ final class ProjectImporterTest extends KernelTestBase {
     self::assertCount(3, $storage->loadMultiple());
   }
 
-  /**
-   * @covers ::batchFinished
-   */
   public function testBatchFinishedOnSuccess(): void {
     ProjectImporter::batchFinished(TRUE, ['processed' => 6, 'type' => 'project_module'], []);
 
@@ -168,9 +145,6 @@ final class ProjectImporterTest extends KernelTestBase {
     self::assertEquals('Total 6 module imported.', (string) $messages[0]);
   }
 
-  /**
-   * @covers ::batchFinished
-   */
   public function testBatchFinishedOnFailure(): void {
     ProjectImporter::batchFinished(FALSE, [], [['do_the_thing', ['an argument']]]);
 

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectInsertVersionsUpdatedTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectInsertVersionsUpdatedTest.php
@@ -7,11 +7,12 @@ use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\simplytest_projects\Entity\SimplytestProject;
 use Drupal\simplytest_projects\ProjectTypes;
 use Drupal\simplytest_projects\ProjectVersionManager;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
-/**
- * @group simplytest
- * @group simplytest_projects
- */
+#[Group('simplytest')]
+#[Group('simplytest_projects')]
+#[RunTestsInSeparateProcesses]
 final class ProjectInsertVersionsUpdatedTest extends KernelTestBase {
 
   protected static $modules = [

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectPreSaveValidationTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectPreSaveValidationTest.php
@@ -9,11 +9,12 @@ use Drupal\simplytest_projects\Entity\SimplytestProject;
 use Drupal\simplytest_projects\Exception\EntityValidationException;
 use Drupal\simplytest_projects\ProjectTypes;
 use Drupal\simplytest_projects\ProjectVersionManager;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
-/**
- * @group simplytest
- * @group simplytest_projects
- */
+#[Group('simplytest')]
+#[Group('simplytest_projects')]
+#[RunTestsInSeparateProcesses]
 final class ProjectPreSaveValidationTest extends KernelTestBase {
 
   protected static $modules = [

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectRefresherTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectRefresherTest.php
@@ -9,15 +9,19 @@ use Drupal\Core\Queue\SuspendQueueException;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\simplytest_projects\Entity\SimplytestProject;
+use Drupal\simplytest_projects\Plugin\QueueWorker\ProjectRefresher;
 use Drupal\simplytest_projects\ProjectTypes;
 use Drupal\simplytest_projects\ProjectVersionManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
-/**
- * @group simplytest
- * @group simplytest_project
- *
- * @coversDefaultClass \Drupal\simplytest_projects\Plugin\QueueWorker\ProjectRefresher
- */
+#[CoversClass(ProjectRefresher::class)]
+#[CoversMethod(ProjectRefresher::class, 'processItem')]
+#[Group('simplytest')]
+#[Group('simplytest_project')]
+#[RunTestsInSeparateProcesses]
 final class ProjectRefresherTest extends KernelTestBase {
 
   protected static $modules = [
@@ -36,9 +40,6 @@ final class ProjectRefresherTest extends KernelTestBase {
       ->createInstance('simplytest_projects_project_refresher');
   }
 
-  /**
-   * @covers ::processItem
-   */
   public function testProcessItem(): void {
     $project = $this->createProject('token');
     $this->setTimestamp($project, 0);
@@ -59,8 +60,6 @@ final class ProjectRefresherTest extends KernelTestBase {
 
   /**
    * A queue item pointing at a deleted project is logged and dropped.
-   *
-   * @covers ::processItem
    */
   public function testProcessItemForMissingProject(): void {
     $this->sut->processItem(9999);
@@ -73,8 +72,6 @@ final class ProjectRefresherTest extends KernelTestBase {
 
   /**
    * A 5xx from Drupal.org suspends the queue rather than burning items.
-   *
-   * @covers ::processItem
    */
   public function testProcessItemSuspendsQueueWhenDrupalOrgIsDown(): void {
     // Insert directly: creating the entity would trip the same mocked
@@ -97,8 +94,6 @@ final class ProjectRefresherTest extends KernelTestBase {
 
   /**
    * A project without release history still gets its timestamp bumped.
-   *
-   * @covers ::processItem
    */
   public function testProcessItemToleratesOtherApiFailures(): void {
     $project = $this->createProject('notfound');
@@ -111,8 +106,6 @@ final class ProjectRefresherTest extends KernelTestBase {
 
   /**
    * A project that no longer validates is logged instead of throwing.
-   *
-   * @covers ::processItem
    */
   public function testProcessItemLogsValidationErrors(): void {
     $project = $this->createProject('token');

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectSeederTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectSeederTest.php
@@ -10,14 +10,17 @@ use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\simplytest_projects\ProjectSeeder;
 use Drupal\simplytest_projects\ProjectVersionManager;
 use Drupal\simplytest_projects_test\TestDatabaseLockBackend;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\DependencyInjection\Reference;
 
-/**
- * @group simplytest
- * @group simplytest_project
- *
- * @coversDefaultClass \Drupal\simplytest_projects\ProjectSeeder
- */
+#[CoversClass(ProjectSeeder::class)]
+#[CoversMethod(ProjectSeeder::class, 'seed')]
+#[Group('simplytest')]
+#[Group('simplytest_project')]
+#[RunTestsInSeparateProcesses]
 final class ProjectSeederTest extends KernelTestBase {
 
   protected static $modules = [
@@ -35,6 +38,7 @@ final class ProjectSeederTest extends KernelTestBase {
     $this->sut = $this->container->get('simplytest_projects.seeder');
   }
 
+  #[\Override]
   public function register(ContainerBuilder $container): void {
     parent::register($container);
     $container
@@ -42,9 +46,6 @@ final class ProjectSeederTest extends KernelTestBase {
       ->addArgument(new Reference('database'));
   }
 
-  /**
-   * @covers ::seed
-   */
   public function testSeedsStarterProjects(): void {
     $seeded = $this->sut->seed();
     self::assertEquals(array_keys(ProjectSeeder::STARTER_PROJECTS), $seeded);
@@ -74,17 +75,12 @@ final class ProjectSeederTest extends KernelTestBase {
     self::assertNotEmpty($releases);
   }
 
-  /**
-   * @covers ::seed
-   */
   public function testSkipsUnfetchableProjects(): void {
     self::assertEquals(['token'], $this->sut->seed(['notaproject', 'token']));
   }
 
   /**
    * Seeding twice must not fail or duplicate projects.
-   *
-   * @covers ::seed
    */
   public function testSeedIsIdempotent(): void {
     $this->sut->seed(['token']);

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectVersionManagerQueriesTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectVersionManagerQueriesTest.php
@@ -4,18 +4,28 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\simplytest_projects\Kernel;
 
+use Composer\Semver\Semver;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\simplytest_projects\ProjectVersionManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Covers the read side of the project version manager.
  *
- * @group simplytest
- * @group simplytest_project
  *
- * @coversDefaultClass \Drupal\simplytest_projects\ProjectVersionManager
  */
+#[CoversClass(ProjectVersionManager::class)]
+#[CoversMethod(ProjectVersionManager::class, 'getRelease')]
+#[CoversMethod(ProjectVersionManager::class, 'getAllReleases')]
+#[CoversMethod(ProjectVersionManager::class, 'getCompatibleReleases')]
+#[CoversMethod(ProjectVersionManager::class, 'organizeAndSortReleases')]
+#[Group('simplytest')]
+#[Group('simplytest_project')]
+#[RunTestsInSeparateProcesses]
 final class ProjectVersionManagerQueriesTest extends KernelTestBase {
 
   protected static $modules = [
@@ -33,9 +43,6 @@ final class ProjectVersionManagerQueriesTest extends KernelTestBase {
     $this->sut->updateData('token');
   }
 
-  /**
-   * @covers ::getRelease
-   */
   public function testGetRelease(): void {
     $release = $this->sut->getRelease('token', '8.x-1.9');
 
@@ -47,8 +54,6 @@ final class ProjectVersionManagerQueriesTest extends KernelTestBase {
 
   /**
    * A branch is looked up as its matching dev release.
-   *
-   * @covers ::getRelease
    */
   public function testGetReleaseExpandsBranchToDev(): void {
     $branch = $this->sut->getRelease('token', '8.x-1.x');
@@ -58,17 +63,11 @@ final class ProjectVersionManagerQueriesTest extends KernelTestBase {
     self::assertEquals($dev, $branch);
   }
 
-  /**
-   * @covers ::getRelease
-   */
   public function testGetReleaseReturnsNullWhenMissing(): void {
     self::assertNull($this->sut->getRelease('token', '8.x-99.0'));
     self::assertNull($this->sut->getRelease('notaproject', '1.0.0'));
   }
 
-  /**
-   * @covers ::getAllReleases
-   */
   public function testGetAllReleasesIsSortedNewestFirst(): void {
     $releases = $this->sut->getAllReleases('token');
 
@@ -79,9 +78,6 @@ final class ProjectVersionManagerQueriesTest extends KernelTestBase {
     self::assertEquals($sorted, $dates);
   }
 
-  /**
-   * @covers ::getCompatibleReleases
-   */
   public function testGetCompatibleReleases(): void {
     $compatible = $this->sut->getCompatibleReleases('token', '9.5.0');
     self::assertNotEmpty($compatible);
@@ -91,13 +87,10 @@ final class ProjectVersionManagerQueriesTest extends KernelTestBase {
 
     // Nothing in the result set excludes Drupal 9.
     foreach ($compatible as $release) {
-      self::assertTrue(\Composer\Semver\Semver::satisfies('9.5.0', $release->core_compatibility));
+      self::assertTrue(Semver::satisfies('9.5.0', $release->core_compatibility));
     }
   }
 
-  /**
-   * @covers ::organizeAndSortReleases
-   */
   public function testOrganizeAndSortReleasesWithNoReleases(): void {
     self::assertEquals(
       ['latest' => [], 'branches' => [], 'core' => []],
@@ -107,8 +100,6 @@ final class ProjectVersionManagerQueriesTest extends KernelTestBase {
 
   /**
    * A release whose compatibility is not a valid constraint is skipped.
-   *
-   * @covers ::organizeAndSortReleases
    */
   public function testOrganizeAndSortReleasesSkipsUnparseableCompatibility(): void {
     $releases = [
@@ -136,8 +127,6 @@ final class ProjectVersionManagerQueriesTest extends KernelTestBase {
 
   /**
    * Dev branches are grouped separately from tagged releases.
-   *
-   * @covers ::organizeAndSortReleases
    */
   public function testOrganizeAndSortReleasesSeparatesBranches(): void {
     $organized = $this->sut->organizeAndSortReleases($this->sut->getAllReleases('token'));

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectVersionManagerTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectVersionManagerTest.php
@@ -6,10 +6,14 @@ use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_projects\ProjectVersionManager;
 use Drupal\Tests\simplytest_projects\Traits\MockedReleaseHttpClientTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
-/**
- * @coversDefaultClass \Drupal\simplytest_projects\ProjectVersionManager
- */
+#[CoversClass(ProjectVersionManager::class)]
+#[CoversMethod(ProjectVersionManager::class, 'updateData')]
+#[CoversMethod(ProjectVersionManager::class, 'getAllReleases')]
+#[RunTestsInSeparateProcesses]
 final class ProjectVersionManagerTest extends KernelTestBase {
 
   use MockedReleaseHttpClientTrait;
@@ -20,6 +24,7 @@ final class ProjectVersionManagerTest extends KernelTestBase {
 
   private ProjectVersionManager $sut;
 
+  #[\Override]
   public function register(ContainerBuilder $container): void {
     parent::register($container);
     self::registerWithContainer($container, $this);
@@ -31,9 +36,6 @@ final class ProjectVersionManagerTest extends KernelTestBase {
     $this->sut = $this->container->get('simplytest_projects.project_version_manager');
   }
 
-  /**
-   * @covers ::updateData
-   */
   public function testUpdateData(): void {
     $this->sut->updateData('pathauto');
     $database = $this->container->get('database');
@@ -52,8 +54,6 @@ final class ProjectVersionManagerTest extends KernelTestBase {
    * A conditional request is only valid while the previous fetch's rows are
    * still stored; when they are gone, a 304 must not leave the project
    * permanently versionless.
-   *
-   * @covers ::updateData
    */
   public function testUpdateDataRefetchesWhenRowsAreGone(): void {
     $this->sut->updateData('pathauto');
@@ -85,9 +85,6 @@ final class ProjectVersionManagerTest extends KernelTestBase {
     self::assertEquals(1, $count);
   }
 
-  /**
-   * @covers ::getAllReleases
-   */
   public function testGetAllReleases(): void {
     $this->sut->updateData('pathauto');
     $releases = $this->sut->getAllReleases('pathauto');

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectsControllerTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/ProjectsControllerTest.php
@@ -8,19 +8,28 @@ use Drupal\Component\Serialization\Json;
 use Drupal\Core\Cache\CacheableJsonResponse;
 use Drupal\Core\Url;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\simplytest_projects\Controller\SimplyTestProjects;
 use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\simplytest_projects\Entity\SimplytestProject;
 use Drupal\simplytest_projects\ProjectTypes;
 use Drupal\simplytest_projects\ProjectVersionManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-/**
- * @group simplytest
- * @group simplytest_project
- *
- * @coversDefaultClass \Drupal\simplytest_projects\Controller\SimplyTestProjects
- */
+#[CoversClass(SimplyTestProjects::class)]
+#[CoversMethod(SimplyTestProjects::class, 'autocompleteProjects')]
+#[CoversMethod(SimplyTestProjects::class, 'lookupProject')]
+#[CoversMethod(SimplyTestProjects::class, 'projectVersions')]
+#[CoversMethod(SimplyTestProjects::class, 'compatibleProjectVersions')]
+#[CoversMethod(SimplyTestProjects::class, 'compatibleCoreVersions')]
+#[CoversMethod(SimplyTestProjects::class, 'coreVersions')]
+#[Group('simplytest')]
+#[Group('simplytest_project')]
+#[RunTestsInSeparateProcesses]
 final class ProjectsControllerTest extends KernelTestBase {
 
   protected static $modules = [
@@ -35,9 +44,6 @@ final class ProjectsControllerTest extends KernelTestBase {
     $this->installSchema('simplytest_projects', ProjectVersionManager::TABLE_NAME);
   }
 
-  /**
-   * @covers ::autocompleteProjects
-   */
   public function testAutocompleteFindsStoredProject(): void {
     SimplytestProject::create([
       'title' => 'Token',
@@ -59,8 +65,6 @@ final class ProjectsControllerTest extends KernelTestBase {
    * Falling through to a Drupal.org API request for every unmatched search
    * string generated abusive request volume; unknown strings return an empty
    * list and the client offers the explicit lookup endpoint instead.
-   *
-   * @covers ::autocompleteProjects
    */
   public function testAutocompleteDoesNotImport(): void {
     self::assertEquals([], $this->requestJson(Url::fromRoute('simplytest_projects.projects', [], [
@@ -70,8 +74,6 @@ final class ProjectsControllerTest extends KernelTestBase {
 
   /**
    * An explicit lookup imports the project, normalizing the typed name.
-   *
-   * @covers ::lookupProject
    */
   public function testLookupImportsProject(): void {
     $response = $this->lookup('Admin Toolbar');
@@ -90,17 +92,11 @@ final class ProjectsControllerTest extends KernelTestBase {
     self::assertEquals('admin_toolbar', $matches[0]['shortname']);
   }
 
-  /**
-   * @covers ::lookupProject
-   */
   public function testLookupUnknownProject(): void {
     $response = $this->lookup('notaproject');
     self::assertEquals(404, $response->getStatusCode());
   }
 
-  /**
-   * @covers ::lookupProject
-   */
   public function testLookupInvalidName(): void {
     $response = $this->lookup('not/a/project!');
     self::assertEquals(400, $response->getStatusCode());
@@ -109,8 +105,6 @@ final class ProjectsControllerTest extends KernelTestBase {
 
   /**
    * Lookups are flood limited so the endpoint cannot relay request spam.
-   *
-   * @covers ::lookupProject
    */
   public function testLookupFloodLimit(): void {
     $flood = $this->container->get('flood');
@@ -134,25 +128,16 @@ final class ProjectsControllerTest extends KernelTestBase {
     ));
   }
 
-  /**
-   * @covers ::autocompleteProjects
-   */
   public function testAutocompleteWithoutSearchString(): void {
     self::assertEquals([], $this->requestJson(Url::fromRoute('simplytest_projects.projects')));
   }
 
-  /**
-   * @covers ::autocompleteProjects
-   */
   public function testAutocompleteWithNoMatchAtAll(): void {
     self::assertEquals([], $this->requestJson(Url::fromRoute('simplytest_projects.projects', [], [
       'query' => ['string' => 'notaproject'],
     ])));
   }
 
-  /**
-   * @covers ::projectVersions
-   */
   public function testProjectVersions(): void {
     $this->container->get('simplytest_projects.project_version_manager')->updateData('token');
 
@@ -167,9 +152,6 @@ final class ProjectsControllerTest extends KernelTestBase {
     self::assertNotEmpty($data['list']['latest']);
   }
 
-  /**
-   * @covers ::compatibleProjectVersions
-   */
   public function testCompatibleProjectVersions(): void {
     $this->container->get('simplytest_projects.project_version_manager')->updateData('token');
 
@@ -185,9 +167,6 @@ final class ProjectsControllerTest extends KernelTestBase {
     }
   }
 
-  /**
-   * @covers ::compatibleCoreVersions
-   */
   public function testCompatibleCoreVersions(): void {
     $this->container->get('simplytest_projects.project_version_manager')->updateData('token');
     $this->container->get('simplytest_projects.core_version_manager')->updateData(9);
@@ -208,9 +187,6 @@ final class ProjectsControllerTest extends KernelTestBase {
     );
   }
 
-  /**
-   * @covers ::compatibleCoreVersions
-   */
   public function testCompatibleCoreVersionsForUnknownRelease(): void {
     $url = Url::fromRoute('simplytest_projects.compatible_core_versions', [
       'project' => 'token',
@@ -222,9 +198,6 @@ final class ProjectsControllerTest extends KernelTestBase {
     self::assertEquals(['notfound'], Json::decode((string) $response->getContent()));
   }
 
-  /**
-   * @covers ::coreVersions
-   */
   public function testCoreVersions(): void {
     $this->container->get('simplytest_projects.core_version_manager')->updateData(9);
 

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/RetryMiddlewareTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/RetryMiddlewareTest.php
@@ -6,23 +6,24 @@ namespace Drupal\Tests\simplytest_projects\Kernel;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\simplytest_projects\Http\Middleware\RetryMiddleware;
-use GuzzleHttp\Exception\ConnectException;
+use Drupal\simplytest_projects\Http\Middleware\RetryMiddlewareFactory;
 use GuzzleHttp\Promise\FulfilledPromise;
-use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Psr\Http\Message\RequestInterface;
 
 /**
  * Tests the RetryMiddleware.
  *
- * @group simplytest
- * @group simplytest_project
  *
- * @coversDefaultClass \Drupal\simplytest_projects\Http\Middleware\RetryMiddlewareFactory
  */
+#[CoversClass(RetryMiddlewareFactory::class)]
+#[Group('simplytest')]
+#[Group('simplytest_project')]
+#[RunTestsInSeparateProcesses]
 final class RetryMiddlewareTest extends KernelTestBase
 {
 
@@ -43,6 +44,7 @@ final class RetryMiddlewareTest extends KernelTestBase
   /**
    * {@inheritdoc}
    */
+  #[\Override]
   public function register(ContainerBuilder $container): void
   {
     parent::register($container);

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/SimplytestProjectEntityTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/SimplytestProjectEntityTest.php
@@ -10,13 +10,28 @@ use Drupal\simplytest_projects\Entity\SimplytestProject;
 use Drupal\simplytest_projects\Exception\EntityValidationException;
 use Drupal\simplytest_projects\ProjectTypes;
 use Drupal\simplytest_projects\ProjectVersionManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
-/**
- * @group simplytest
- * @group simplytest_project
- *
- * @coversDefaultClass \Drupal\simplytest_projects\Entity\SimplytestProject
- */
+#[CoversClass(SimplytestProject::class)]
+#[CoversMethod(SimplytestProject::class, 'label')]
+#[CoversMethod(SimplytestProject::class, 'getShortname')]
+#[CoversMethod(SimplytestProject::class, 'getType')]
+#[CoversMethod(SimplytestProject::class, 'getCreator')]
+#[CoversMethod(SimplytestProject::class, 'isSandbox')]
+#[CoversMethod(SimplytestProject::class, 'getTimestamp')]
+#[CoversMethod(SimplytestProject::class, 'getGitUrl')]
+#[CoversMethod(SimplytestProject::class, 'getGitWebUrl')]
+#[CoversMethod(SimplytestProject::class, 'getProjectUrl')]
+#[CoversMethod(SimplytestProject::class, 'getCreatorEscaped')]
+#[CoversMethod(SimplytestProject::class, 'getVersions')]
+#[CoversMethod(SimplytestProject::class, 'setVersions')]
+#[CoversMethod(SimplytestProject::class, 'preSave')]
+#[Group('simplytest')]
+#[Group('simplytest_project')]
+#[RunTestsInSeparateProcesses]
 final class SimplytestProjectEntityTest extends KernelTestBase {
 
   protected static $modules = [
@@ -31,14 +46,6 @@ final class SimplytestProjectEntityTest extends KernelTestBase {
     $this->installSchema('simplytest_projects', ProjectVersionManager::TABLE_NAME);
   }
 
-  /**
-   * @covers ::label
-   * @covers ::getShortname
-   * @covers ::getType
-   * @covers ::getCreator
-   * @covers ::isSandbox
-   * @covers ::getTimestamp
-   */
   public function testFullProjectAccessors(): void {
     $project = $this->createProject([
       'title' => 'Token',
@@ -56,11 +63,6 @@ final class SimplytestProjectEntityTest extends KernelTestBase {
     self::assertGreaterThan(0, $project->getTimestamp());
   }
 
-  /**
-   * @covers ::getGitUrl
-   * @covers ::getGitWebUrl
-   * @covers ::getProjectUrl
-   */
   public function testFullProjectUrls(): void {
     $project = $this->createProject([
       'title' => 'Token',
@@ -74,12 +76,6 @@ final class SimplytestProjectEntityTest extends KernelTestBase {
     self::assertEquals('https://www.drupal.org/project/token', $project->getProjectUrl());
   }
 
-  /**
-   * @covers ::getGitUrl
-   * @covers ::getGitWebUrl
-   * @covers ::getProjectUrl
-   * @covers ::getCreatorEscaped
-   */
   public function testSandboxProjectUrls(): void {
     $project = $this->createProject([
       'title' => 'A sandbox',
@@ -97,10 +93,6 @@ final class SimplytestProjectEntityTest extends KernelTestBase {
     self::assertEquals('https://www.drupal.org/sandbox/someuser!/a_sandbox', $project->getProjectUrl());
   }
 
-  /**
-   * @covers ::getVersions
-   * @covers ::setVersions
-   */
   public function testVersions(): void {
     $project = $this->createProject([
       'title' => 'Token',
@@ -119,9 +111,6 @@ final class SimplytestProjectEntityTest extends KernelTestBase {
     ], $project->getVersions());
   }
 
-  /**
-   * @covers ::preSave
-   */
   public function testPreSaveRejectsDuplicateShortname(): void {
     $this->createProject([
       'title' => 'Token',

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/SimplytestProjectStorageSchemaTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/SimplytestProjectStorageSchemaTest.php
@@ -5,11 +5,16 @@ declare(strict_types=1);
 namespace Drupal\Tests\simplytest_projects\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\simplytest_projects\SimplytestProjectStorageSchema;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
-/**
- * @coversDefaultClass \Drupal\simplytest_projects\SimplytestProjectStorageSchema
- * @group simplytest_projects
- */
+#[CoversClass(SimplytestProjectStorageSchema::class)]
+#[CoversMethod(SimplytestProjectStorageSchema::class, 'getEntitySchema')]
+#[Group('simplytest_projects')]
+#[RunTestsInSeparateProcesses]
 final class SimplytestProjectStorageSchemaTest extends KernelTestBase {
 
   /**
@@ -23,8 +28,6 @@ final class SimplytestProjectStorageSchemaTest extends KernelTestBase {
 
   /**
    * A fresh install indexes the columns projects are looked up by.
-   *
-   * @covers ::getEntitySchema
    */
   public function testInstallCreatesLookupIndexes(): void {
     $this->installEntitySchema('simplytest_project');

--- a/web/modules/custom/simplytest_projects/tests/src/Kernel/UpdateHooksTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Kernel/UpdateHooksTest.php
@@ -7,16 +7,25 @@ namespace Drupal\Tests\simplytest_projects\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\simplytest_projects\ProjectVersionManager;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Covers the module's update hooks.
  *
  * The schemas are deliberately not installed in setUp(): the update hooks are
  * what put them there, which is the behavior under test.
- *
- * @group simplytest
- * @group simplytest_project
  */
+#[CoversFunction('simplytest_projects_schema')]
+#[CoversFunction('simplytest_projects_update_9001')]
+#[CoversFunction('simplytest_projects_update_9002')]
+#[CoversFunction('simplytest_projects_update_9004')]
+#[CoversFunction('simplytest_projects_update_9005')]
+#[CoversFunction('simplytest_projects_update_9006')]
+#[Group('simplytest')]
+#[Group('simplytest_project')]
+#[RunTestsInSeparateProcesses]
 final class UpdateHooksTest extends KernelTestBase {
 
   protected static $modules = [
@@ -31,9 +40,6 @@ final class UpdateHooksTest extends KernelTestBase {
     $this->container->get('module_handler')->loadInclude('simplytest_projects', 'install');
   }
 
-  /**
-   * @covers ::simplytest_projects_schema
-   */
   public function testSchemaDefinition(): void {
     $schema = simplytest_projects_schema();
 
@@ -46,9 +52,6 @@ final class UpdateHooksTest extends KernelTestBase {
     );
   }
 
-  /**
-   * @covers ::simplytest_projects_update_9001
-   */
   public function testUpdate9001CreatesCoreVersionsTable(): void {
     $db_schema = $this->container->get('database')->schema();
     self::assertFalse($db_schema->tableExists(CoreVersionManager::TABLE_NAME));
@@ -58,9 +61,6 @@ final class UpdateHooksTest extends KernelTestBase {
     self::assertTrue($db_schema->tableExists(CoreVersionManager::TABLE_NAME));
   }
 
-  /**
-   * @covers ::simplytest_projects_update_9002
-   */
   public function testUpdate9002CreatesProjectVersionsTable(): void {
     $db_schema = $this->container->get('database')->schema();
     self::assertFalse($db_schema->tableExists(ProjectVersionManager::TABLE_NAME));
@@ -70,9 +70,6 @@ final class UpdateHooksTest extends KernelTestBase {
     self::assertTrue($db_schema->tableExists(ProjectVersionManager::TABLE_NAME));
   }
 
-  /**
-   * @covers ::simplytest_projects_update_9004
-   */
   public function testUpdate9004RefreshesCoreReleaseData(): void {
     simplytest_projects_update_9001();
     simplytest_projects_update_9002();
@@ -86,9 +83,6 @@ final class UpdateHooksTest extends KernelTestBase {
     self::assertNotEmpty($this->container->get('simplytest_projects.core_version_manager')->getVersions(10));
   }
 
-  /**
-   * @covers ::simplytest_projects_update_9005
-   */
   public function testUpdate9005ChangesVersionFieldsToIntegers(): void {
     simplytest_projects_update_9001();
 
@@ -111,9 +105,6 @@ final class UpdateHooksTest extends KernelTestBase {
     self::assertCount(1, $versions);
   }
 
-  /**
-   * @covers ::simplytest_projects_update_9006
-   */
   public function testUpdate9006RemovesLegacyQueueItems(): void {
     $database = $this->container->get('database');
     $database->schema()->createTable('queue', [

--- a/web/modules/custom/simplytest_projects/tests/src/Unit/ReleaseHistory/FetcherTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Unit/ReleaseHistory/FetcherTest.php
@@ -10,12 +10,13 @@ use Drupal\simplytest_projects\Exception\ReleaseHistoryNotModifiedException;
 use Drupal\simplytest_projects\ReleaseHistory\Fetcher;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests fetching release data
- *
- * @coversDefaultClass \Drupal\simplytest_projects\ReleaseHistory\Fetcher
  */
+#[CoversClass(Fetcher::class)]
 final class FetcherTest extends ReleaseHistoryUnitTestBase {
 
   public function testLastModified() {
@@ -29,9 +30,8 @@ final class FetcherTest extends ReleaseHistoryUnitTestBase {
   /**
    * @param string $channel
    * @param bool $expected_exception
-   *
-   * @dataProvider releaseChannelData
    */
+  #[DataProvider('releaseChannelData')]
   public function testValidReleaseChannels(string $channel, bool $expected_exception): void {
     $state = new State(new KeyValueMemoryFactory(), new NullBackend('bootstrap'), new NullLockBackend());
 

--- a/web/modules/custom/simplytest_projects/tests/src/Unit/ReleaseHistory/ProcessorTest.php
+++ b/web/modules/custom/simplytest_projects/tests/src/Unit/ReleaseHistory/ProcessorTest.php
@@ -11,17 +11,16 @@ use Drupal\simplytest_projects\ReleaseHistory\Processor;
 use Drupal\simplytest_projects\ReleaseHistory\ProjectRelease;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
 
 /**
  * Tests processing of release history data
- *
- * @coversDefaultClass \Drupal\simplytest_projects\ReleaseHistory\Processor
  */
+#[CoversClass(Processor::class)]
+#[CoversMethod(Processor::class, 'getData')]
 final class ProcessorTest extends ReleaseHistoryUnitTestBase {
 
-  /**
-   * @covers ::getData
-   */
   public function testGetData() {
     $stack = HandlerStack::create();
     $stack->push($this());

--- a/web/modules/custom/simplytest_tugboat/src/PreviewConfigGenerator.php
+++ b/web/modules/custom/simplytest_tugboat/src/PreviewConfigGenerator.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\simplytest_tugboat;
 
-use Composer\Semver\Semver;
 use Drupal\simplytest_ocd\OneClickDemoInterface;
 use Drupal\simplytest_ocd\OneClickDemoPluginManager;
 use Drupal\simplytest_projects\ProjectTypes;

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/BasePreviewCronTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/BasePreviewCronTest.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace Drupal\Tests\simplytest_tugboat\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Covers the cron run that keeps base previews fresh.
- *
- * @group simplytest
- * @group simplytest_tugboat
  */
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
+#[RunTestsInSeparateProcesses]
 final class BasePreviewCronTest extends KernelTestBase {
 
   private const string CREATE_URL = 'https://api.tugboatqa.com/v3/previews';

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/BasePreviewManagerTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/BasePreviewManagerTest.php
@@ -6,15 +6,26 @@ namespace Drupal\Tests\simplytest_tugboat\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_tugboat\BasePreviewManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Covers how base previews are found, rebuilt, and retired.
  *
- * @group simplytest
- * @group simplytest_tugboat
  *
- * @coversDefaultClass \Drupal\simplytest_tugboat\BasePreviewManager
  */
+#[CoversClass(BasePreviewManager::class)]
+#[CoversMethod(BasePreviewManager::class, 'names')]
+#[CoversMethod(BasePreviewManager::class, 'findUsable')]
+#[CoversMethod(BasePreviewManager::class, 'rebuild')]
+#[CoversMethod(BasePreviewManager::class, 'rebuildAll')]
+#[CoversMethod(BasePreviewManager::class, 'prune')]
+#[CoversMethod(BasePreviewManager::class, 'inventory')]
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
+#[RunTestsInSeparateProcesses]
 final class BasePreviewManagerTest extends KernelTestBase {
 
   protected static $modules = [
@@ -38,8 +49,6 @@ final class BasePreviewManagerTest extends KernelTestBase {
 
   /**
    * Every supported core major and every one click demo gets a base.
-   *
-   * @covers ::names
    */
   public function testNames(): void {
     self::assertEquals(
@@ -50,8 +59,6 @@ final class BasePreviewManagerTest extends KernelTestBase {
 
   /**
    * The newest base that can be built on wins.
-   *
-   * @covers ::findUsable
    */
   public function testFindUsable(): void {
     // Not the one still building, and not the older ones.
@@ -70,8 +77,6 @@ final class BasePreviewManagerTest extends KernelTestBase {
 
   /**
    * A rebuild is a fresh preview with generated config and the base name.
-   *
-   * @covers ::rebuild
    */
   public function testRebuild(): void {
     self::assertEquals('abc123', $this->sut->rebuild('drupal10'));
@@ -90,8 +95,6 @@ final class BasePreviewManagerTest extends KernelTestBase {
 
   /**
    * One refused base does not stop the rest.
-   *
-   * @covers ::rebuildAll
    */
   public function testRebuildAllContinuesPastFailures(): void {
     $this->config('tugboat.settings')->set('repository_id', 'brokenrepo')->save();
@@ -105,9 +108,6 @@ final class BasePreviewManagerTest extends KernelTestBase {
     self::assertTrue($logger->hasMessageContaining('Tugboat refused to build base preview commerce'));
   }
 
-  /**
-   * @covers ::rebuildAll
-   */
   public function testRebuildAll(): void {
     $started = $this->sut->rebuildAll();
     self::assertEquals(array_fill_keys($this->sut->names(), 'abc123'), $started);
@@ -115,8 +115,6 @@ final class BasePreviewManagerTest extends KernelTestBase {
 
   /**
    * Only replaced bases nothing builds on, and failed builds, are deleted.
-   *
-   * @covers ::prune
    */
   public function testPrune(): void {
     $deleted = $this->sut->prune();
@@ -132,8 +130,6 @@ final class BasePreviewManagerTest extends KernelTestBase {
 
   /**
    * The inventory lists every base, newest first, including missing ones.
-   *
-   * @covers ::inventory
    */
   public function testInventory(): void {
     $inventory = $this->sut->inventory();

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/InstanceManagerBranchesTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/InstanceManagerBranchesTest.php
@@ -4,22 +4,30 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\simplytest_tugboat\Kernel;
 
+use Drupal\simplytest_tugboat\InstanceManager;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\simplytest_projects\Entity\SimplytestProject;
 use Drupal\simplytest_projects\ProjectTypes;
 use Drupal\simplytest_projects\ProjectVersionManager;
-use Drupal\simplytest_tugboat\LaunchRecorder;
 use Drupal\simplytest_tugboat\InstanceManagerInterface;
+use Drupal\simplytest_tugboat\LaunchRecorder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Covers the launch paths the happy-path test does not reach.
  *
- * @group simplytest
- * @group simplytest_tugboat
  *
- * @coversDefaultClass \Drupal\simplytest_tugboat\InstanceManager
  */
+#[CoversClass(InstanceManager::class)]
+#[CoversMethod(InstanceManager::class, 'loadPreviewId')]
+#[CoversMethod(InstanceManager::class, 'launchInstance')]
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
+#[RunTestsInSeparateProcesses]
 final class InstanceManagerBranchesTest extends KernelTestBase {
 
   protected static $modules = [
@@ -50,9 +58,6 @@ final class InstanceManagerBranchesTest extends KernelTestBase {
     $this->sut = $this->container->get('simplytest_tugboat.instance_manager');
   }
 
-  /**
-   * @covers ::loadPreviewId
-   */
   public function testLoadPreviewId(): void {
     self::assertEquals('base-drupal9-id', $this->sut->loadPreviewId('drupal9'));
     self::assertEquals('base-umami-id', $this->sut->loadPreviewId('umami'));
@@ -60,8 +65,6 @@ final class InstanceManagerBranchesTest extends KernelTestBase {
 
   /**
    * A context with no base preview reports a sentinel rather than failing.
-   *
-   * @covers ::loadPreviewId
    */
   public function testLoadPreviewIdForUnknownContext(): void {
     self::assertEquals('none', $this->sut->loadPreviewId('drupal42'));
@@ -71,8 +74,6 @@ final class InstanceManagerBranchesTest extends KernelTestBase {
 
   /**
    * A base name is never matched without its prefix.
-   *
-   * @covers ::loadPreviewId
    */
   public function testLoadPreviewIdIgnoresSandboxes(): void {
     // A sandbox named after the branch it was built from is not a base.
@@ -81,8 +82,6 @@ final class InstanceManagerBranchesTest extends KernelTestBase {
 
   /**
    * A one-click demo is a clone of its base preview, which is the demo.
-   *
-   * @covers ::launchInstance
    */
   public function testLaunchOneClickDemo(): void {
     $this->config('tugboat.settings')->set('sandbox_lifetime', 7200)->save();
@@ -107,8 +106,6 @@ final class InstanceManagerBranchesTest extends KernelTestBase {
 
   /**
    * A demo with no usable base is built from scratch, from the plugin.
-   *
-   * @covers ::launchInstance
    */
   public function testLaunchOneClickDemoWithoutBase(): void {
     // The mocked repository has no base-starshot preview.
@@ -127,8 +124,6 @@ final class InstanceManagerBranchesTest extends KernelTestBase {
 
   /**
    * A manual install skips the install step in the generated config.
-   *
-   * @covers ::launchInstance
    */
   public function testLaunchWithManualInstall(): void {
     $this->sut->launchInstance($this->submission(['manualInstall' => TRUE]));
@@ -140,8 +135,6 @@ final class InstanceManagerBranchesTest extends KernelTestBase {
 
   /**
    * Patches are applied, and empty entries are dropped.
-   *
-   * @covers ::launchInstance
    */
   public function testLaunchWithPatches(): void {
     $submission = $this->submission();
@@ -158,8 +151,6 @@ final class InstanceManagerBranchesTest extends KernelTestBase {
 
   /**
    * Additional projects are resolved to their stored project type.
-   *
-   * @covers ::launchInstance
    */
   public function testLaunchWithAdditionalProjects(): void {
     $this->sut->launchInstance($this->submission([
@@ -179,8 +170,6 @@ final class InstanceManagerBranchesTest extends KernelTestBase {
 
   /**
    * The major version of the requested core drives the base preview.
-   *
-   * @covers ::launchInstance
    */
   public function testLaunchUsesMajorVersionForBasePreview(): void {
     $this->sut->launchInstance($this->submission(['drupalVersion' => '10.1.0']));
@@ -191,8 +180,6 @@ final class InstanceManagerBranchesTest extends KernelTestBase {
 
   /**
    * The response carries the identifiers the launcher polls with.
-   *
-   * @covers ::launchInstance
    */
   public function testLaunchReturnsPreviewIdentifiers(): void {
     $result = $this->sut->launchInstance($this->submission());
@@ -208,8 +195,6 @@ final class InstanceManagerBranchesTest extends KernelTestBase {
 
   /**
    * Every launch is recorded, so the report knows what people evaluate.
-   *
-   * @covers ::launchInstance
    */
   public function testLaunchIsRecorded(): void {
     $submission = $this->submission();
@@ -229,8 +214,6 @@ final class InstanceManagerBranchesTest extends KernelTestBase {
 
   /**
    * A one click demo is recorded by plugin ID, with no project details.
-   *
-   * @covers ::launchInstance
    */
   public function testOneClickDemoIsRecorded(): void {
     $this->sut->launchInstance([
@@ -246,8 +229,6 @@ final class InstanceManagerBranchesTest extends KernelTestBase {
 
   /**
    * A launch Tugboat never accepted is still recorded, as a failure.
-   *
-   * @covers ::launchInstance
    */
   public function testFailedLaunchIsRecorded(): void {
     // This repository ID makes the Tugboat API fail in the mocked middleware.

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/InstanceManagerTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/InstanceManagerTest.php
@@ -4,19 +4,23 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\simplytest_tugboat\Kernel;
 
+use Drupal\simplytest_tugboat\InstanceManager;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\simplytest_projects\Entity\SimplytestProject;
 use Drupal\simplytest_projects\ProjectTypes;
 use Drupal\simplytest_projects\ProjectVersionManager;
 use Drupal\simplytest_tugboat\LaunchRecorder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
-/**
- * @group simplytest
- * @group simplytest_tugboat
- *
- * @coversDefaultClass \Drupal\simplytest_tugboat\InstanceManager
- */
+#[CoversClass(InstanceManager::class)]
+#[CoversMethod(InstanceManager::class, 'launchInstance')]
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
+#[RunTestsInSeparateProcesses]
 final class InstanceManagerTest extends KernelTestBase {
 
 //  protected $runTestInSeparateProcess = FALSE;
@@ -60,9 +64,6 @@ final class InstanceManagerTest extends KernelTestBase {
       ->save();
   }
 
-  /**
-   * @covers ::launchInstance
-   */
   public function testLaunchInstance(): void {
     $sut = $this->container->get('simplytest_tugboat.instance_manager');
 

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchRecorderTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchRecorderTest.php
@@ -7,15 +7,24 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_projects\ProjectTypes;
 use Drupal\simplytest_tugboat\LaunchRecord;
 use Drupal\simplytest_tugboat\LaunchRecorder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
- * @group simplytest
- * @group simplytest_tugboat
- *
- * @coversDefaultClass \Drupal\simplytest_tugboat\LaunchRecorder
  *
  * @phpstan-import-type PreviewParameters from \Drupal\simplytest_tugboat\LaunchRecord
  */
+#[CoversClass(LaunchRecorder::class)]
+#[CoversMethod(LaunchRecorder::class, 'recordLaunch')]
+#[CoversMethod(LaunchRecorder::class, 'write')]
+#[CoversMethod(LaunchRecord::class, 'fromPreviewParameters')]
+#[CoversMethod(LaunchRecord::class, 'forOneClickDemo')]
+#[CoversMethod(LaunchRecorder::class, 'recordFailure')]
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
+#[RunTestsInSeparateProcesses]
 final class LaunchRecorderTest extends KernelTestBase {
 
   protected static $modules = [
@@ -31,11 +40,6 @@ final class LaunchRecorderTest extends KernelTestBase {
     $this->installSchema('simplytest_tugboat', LaunchRecorder::TABLE_NAME);
   }
 
-  /**
-   * @covers ::recordLaunch
-   * @covers ::write
-   * @covers \Drupal\simplytest_tugboat\LaunchRecord::fromPreviewParameters
-   */
   public function testRecordLaunch(): void {
     $this->recorder()->recordLaunch(
       LaunchRecord::fromPreviewParameters($this->previewParameters()),
@@ -58,9 +62,6 @@ final class LaunchRecorderTest extends KernelTestBase {
 
   /**
    * The stored day matches the stored timestamp, in UTC.
-   *
-   * @covers ::recordLaunch
-   * @covers ::write
    */
   public function testRecordLaunchStoresMatchingDay(): void {
     $this->recorder()->recordLaunch(
@@ -74,8 +75,6 @@ final class LaunchRecorderTest extends KernelTestBase {
 
   /**
    * A manual install is stored as such.
-   *
-   * @covers \Drupal\simplytest_tugboat\LaunchRecord::fromPreviewParameters
    */
   public function testRecordLaunchWithManualInstall(): void {
     $parameters = $this->previewParameters();
@@ -87,10 +86,6 @@ final class LaunchRecorderTest extends KernelTestBase {
 
   /**
    * A one click demo records which demo ran and nothing else.
-   *
-   * @covers ::recordLaunch
-   * @covers ::write
-   * @covers \Drupal\simplytest_tugboat\LaunchRecord::forOneClickDemo
    */
   public function testRecordOneClickDemo(): void {
     $this->recorder()->recordLaunch(LaunchRecord::forOneClickDemo('umami'), 'preview-ocd');
@@ -104,9 +99,6 @@ final class LaunchRecorderTest extends KernelTestBase {
 
   /**
    * Writing a row invalidates whatever was rendered from the table.
-   *
-   * @covers ::recordLaunch
-   * @covers ::write
    */
   public function testRecordLaunchInvalidatesCacheTag(): void {
     $cache = $this->container->get('cache.default');
@@ -119,9 +111,6 @@ final class LaunchRecorderTest extends KernelTestBase {
 
   /**
    * A failed launch is recorded without a preview.
-   *
-   * @covers ::recordFailure
-   * @covers ::write
    */
   public function testRecordFailure(): void {
     $this->recorder()->recordFailure(LaunchRecord::fromPreviewParameters($this->previewParameters()));

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchStatisticsComponentTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchStatisticsComponentTest.php
@@ -6,6 +6,8 @@ use Drupal\Core\Plugin\Component;
 use Drupal\Core\Render\Component\Exception\InvalidComponentException;
 use Drupal\Core\Theme\Component\ComponentValidator;
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * The report component enforces the shape of the data it is handed.
@@ -17,10 +19,10 @@ use Drupal\KernelTests\KernelTestBase;
  * So the rejection cases call the validator directly rather than rendering.
  * Going through the render pipeline would only prove the schema on a developer
  * machine, and would pass vacuously everywhere else.
- *
- * @group simplytest
- * @group simplytest_tugboat
  */
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
+#[RunTestsInSeparateProcesses]
 final class LaunchStatisticsComponentTest extends KernelTestBase {
 
   protected static $modules = [

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchStatisticsControllerTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchStatisticsControllerTest.php
@@ -6,13 +6,18 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_projects\ProjectTypes;
 use Drupal\simplytest_tugboat\Controller\LaunchStatisticsController;
 use Drupal\simplytest_tugboat\LaunchRecorder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
-/**
- * @group simplytest
- * @group simplytest_tugboat
- *
- * @coversDefaultClass \Drupal\simplytest_tugboat\Controller\LaunchStatisticsController
- */
+#[CoversClass(LaunchStatisticsController::class)]
+#[CoversMethod(LaunchStatisticsController::class, 'report')]
+#[CoversMethod(LaunchStatisticsController::class, 'peak')]
+#[CoversMethod(LaunchStatisticsController::class, 'labelDemos')]
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
+#[RunTestsInSeparateProcesses]
 final class LaunchStatisticsControllerTest extends KernelTestBase {
 
   protected static $modules = [
@@ -29,9 +34,6 @@ final class LaunchStatisticsControllerTest extends KernelTestBase {
     $this->installSchema('simplytest_tugboat', LaunchRecorder::TABLE_NAME);
   }
 
-  /**
-   * @covers ::report
-   */
   public function testReportWithNoLaunches(): void {
     $output = $this->renderReport();
 
@@ -39,10 +41,6 @@ final class LaunchStatisticsControllerTest extends KernelTestBase {
     self::assertStringContainsString('No launches recorded yet', $output);
   }
 
-  /**
-   * @covers ::report
-   * @covers ::peak
-   */
   public function testReportListsWhatWasLaunched(): void {
     $this->record('token');
     $this->record('token');
@@ -58,9 +56,6 @@ final class LaunchStatisticsControllerTest extends KernelTestBase {
 
   /**
    * Demos are listed by title, and a demo that no longer exists by its ID.
-   *
-   * @covers ::report
-   * @covers ::labelDemos
    */
   public function testReportListsOneClickDemosByTitle(): void {
     $this->recordDemo('starshot');
@@ -77,8 +72,6 @@ final class LaunchStatisticsControllerTest extends KernelTestBase {
 
   /**
    * Failed launches stay out of the public numbers.
-   *
-   * @covers ::report
    */
   public function testReportExcludesFailedLaunches(): void {
     $this->record('token', LaunchRecorder::STATUS_FAILED);
@@ -91,8 +84,6 @@ final class LaunchStatisticsControllerTest extends KernelTestBase {
    *
    * The Expires header carries the same lifetime because the anonymous page
    * cache ignores a render array's max-age and only reads that header.
-   *
-   * @covers ::report
    */
   public function testReportCacheability(): void {
     $now = $this->container->get('datetime.time')->getRequestTime();

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchStatisticsTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/LaunchStatisticsTest.php
@@ -6,13 +6,24 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_projects\ProjectTypes;
 use Drupal\simplytest_tugboat\LaunchRecorder;
 use Drupal\simplytest_tugboat\LaunchStatistics;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
-/**
- * @group simplytest
- * @group simplytest_tugboat
- *
- * @coversDefaultClass \Drupal\simplytest_tugboat\LaunchStatistics
- */
+#[CoversClass(LaunchStatistics::class)]
+#[CoversMethod(LaunchStatistics::class, 'getTotal')]
+#[CoversMethod(LaunchStatistics::class, 'getTopProjects')]
+#[CoversMethod(LaunchStatistics::class, 'topBy')]
+#[CoversMethod(LaunchStatistics::class, 'getTopOneClickDemos')]
+#[CoversMethod(LaunchStatistics::class, 'getTopCoreVersions')]
+#[CoversMethod(LaunchStatistics::class, 'getTopInstallProfiles')]
+#[CoversMethod(LaunchStatistics::class, 'getProjectTypes')]
+#[CoversMethod(LaunchStatistics::class, 'getDailyTotals')]
+#[CoversMethod(LaunchStatistics::class, 'getFirstRecordedAt')]
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
+#[RunTestsInSeparateProcesses]
 final class LaunchStatisticsTest extends KernelTestBase {
 
   protected static $modules = [
@@ -31,9 +42,6 @@ final class LaunchStatisticsTest extends KernelTestBase {
     $this->now = $this->container->get('datetime.time')->getRequestTime();
   }
 
-  /**
-   * @covers ::getTotal
-   */
   public function testGetTotalCountsOnlySuccessfulLaunches(): void {
     $this->record('token', daysAgo: 1);
     $this->record('token', daysAgo: 1, status: LaunchRecorder::STATUS_FAILED);
@@ -41,9 +49,6 @@ final class LaunchStatisticsTest extends KernelTestBase {
     self::assertEquals(1, $this->statistics()->getTotal());
   }
 
-  /**
-   * @covers ::getTotal
-   */
   public function testGetTotalWindowsByDays(): void {
     $this->record('token', daysAgo: 1);
     $this->record('token', daysAgo: 3);
@@ -56,10 +61,6 @@ final class LaunchStatisticsTest extends KernelTestBase {
     self::assertEquals(4, $statistics->getTotal());
   }
 
-  /**
-   * @covers ::getTopProjects
-   * @covers ::topBy
-   */
   public function testGetTopProjectsOrdersByCount(): void {
     $this->record('token', daysAgo: 1);
     $this->record('token', daysAgo: 2);
@@ -78,9 +79,6 @@ final class LaunchStatisticsTest extends KernelTestBase {
     );
   }
 
-  /**
-   * @covers ::getTopProjects
-   */
   public function testGetTopProjectsRespectsTheLimit(): void {
     $this->record('token', daysAgo: 1);
     $this->record('webform', daysAgo: 1);
@@ -91,8 +89,6 @@ final class LaunchStatisticsTest extends KernelTestBase {
 
   /**
    * One click demos leave the project columns empty and must not be grouped.
-   *
-   * @covers ::topBy
    */
   public function testGetTopProjectsSkipsOneClickDemos(): void {
     $this->record('token', daysAgo: 1);
@@ -107,9 +103,6 @@ final class LaunchStatisticsTest extends KernelTestBase {
 
   /**
    * Demos are counted by plugin ID, and normal launches stay out of the list.
-   *
-   * @covers ::getTopOneClickDemos
-   * @covers ::topBy
    */
   public function testGetTopOneClickDemos(): void {
     $this->record('token', daysAgo: 1);
@@ -127,11 +120,6 @@ final class LaunchStatisticsTest extends KernelTestBase {
     );
   }
 
-  /**
-   * @covers ::getTopCoreVersions
-   * @covers ::getTopInstallProfiles
-   * @covers ::getProjectTypes
-   */
   public function testOtherBreakdowns(): void {
     $this->record('token', daysAgo: 1, coreVersion: '10.3.0', installProfile: 'standard');
     $this->record('webform', daysAgo: 1, coreVersion: '10.3.0', installProfile: 'umami');
@@ -154,8 +142,6 @@ final class LaunchStatisticsTest extends KernelTestBase {
 
   /**
    * Quiet days are filled in so a caller can chart the window directly.
-   *
-   * @covers ::getDailyTotals
    */
   public function testGetDailyTotalsFillsQuietDays(): void {
     $this->record('token', daysAgo: 0);
@@ -176,10 +162,6 @@ final class LaunchStatisticsTest extends KernelTestBase {
    * A launch seven days ago sits inside a rolling seven times 24 hour window
    * but on the day before a seven day chart starts. Counting it in the total
    * and not in the chart would leave the page disagreeing with itself.
-   *
-   * @covers ::getTotal
-   * @covers ::getDailyTotals
-   * @covers ::getTopProjects
    */
   public function testWindowsAreWholeCalendarDays(): void {
     $this->record('token', daysAgo: 0);
@@ -194,9 +176,6 @@ final class LaunchStatisticsTest extends KernelTestBase {
     self::assertEquals([['name' => 'token', 'total' => 2]], $statistics->getTopProjects(7, 10));
   }
 
-  /**
-   * @covers ::getFirstRecordedAt
-   */
   public function testGetFirstRecordedAt(): void {
     self::assertNull($this->statistics()->getFirstRecordedAt());
 
@@ -208,9 +187,6 @@ final class LaunchStatisticsTest extends KernelTestBase {
 
   /**
    * An empty table reports zeroes rather than failing.
-   *
-   * @covers ::getTotal
-   * @covers ::getTopProjects
    */
   public function testEmptyTable(): void {
     $statistics = $this->statistics();

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/TugboatControllerTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/TugboatControllerTest.php
@@ -11,15 +11,19 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\simplytest_projects\ProjectVersionManager;
 use Drupal\simplytest_tugboat\Controller\SimplytestTugboatController;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-/**
- * @group simplytest
- * @group simplytest_tugboat
- *
- * @coversDefaultClass \Drupal\simplytest_tugboat\Controller\SimplytestTugboatController
- */
+#[CoversClass(SimplytestTugboatController::class)]
+#[CoversMethod(SimplytestTugboatController::class, 'progress')]
+#[CoversMethod(SimplytestTugboatController::class, 'instanceState')]
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
+#[RunTestsInSeparateProcesses]
 final class TugboatControllerTest extends KernelTestBase {
 
   protected static $modules = [
@@ -46,9 +50,6 @@ final class TugboatControllerTest extends KernelTestBase {
     $this->sut = SimplytestTugboatController::create($this->container);
   }
 
-  /**
-   * @covers ::progress
-   */
   public function testProgressPage(): void {
     $url = Url::fromRoute('simplytest_tugboat.progress', [
       'instance_id' => 'abc123',
@@ -62,8 +63,6 @@ final class TugboatControllerTest extends KernelTestBase {
 
   /**
    * The build array carries the IDs the front end needs.
-   *
-   * @covers ::progress
    */
   public function testProgressBuild(): void {
     $build = $this->sut->progress(Request::create('/'), 'abc123', 'ac123');
@@ -76,8 +75,6 @@ final class TugboatControllerTest extends KernelTestBase {
 
   /**
    * A finished preview reports as ready, cacheable, and fully progressed.
-   *
-   * @covers ::instanceState
    */
   public function testInstanceStateForFinishedPreview(): void {
     $response = $this->sut->instanceState('abc123', 'finished-job');
@@ -93,8 +90,6 @@ final class TugboatControllerTest extends KernelTestBase {
 
   /**
    * Git noise is stripped out of the log before it reaches the front end.
-   *
-   * @covers ::instanceState
    */
   public function testInstanceStateFiltersGitNoise(): void {
     $data = Json::decode((string) $this->sut->instanceState('abc123', 'finished-job')->getContent());
@@ -108,8 +103,6 @@ final class TugboatControllerTest extends KernelTestBase {
 
   /**
    * A suspended preview reports the state it was suspended at.
-   *
-   * @covers ::instanceState
    */
   public function testInstanceStateForSuspendedPreview(): void {
     $data = Json::decode((string) $this->sut->instanceState('abc123', 'suspended-job')->getContent());
@@ -118,8 +111,6 @@ final class TugboatControllerTest extends KernelTestBase {
 
   /**
    * A job that is still building is not cacheable yet.
-   *
-   * @covers ::instanceState
    */
   public function testInstanceStateForRunningJob(): void {
     $response = $this->sut->instanceState('abc123', 'running-job');
@@ -132,9 +123,6 @@ final class TugboatControllerTest extends KernelTestBase {
     self::assertNull($data['url']);
   }
 
-  /**
-   * @covers ::instanceState
-   */
   public function testInstanceStateForMissingJob(): void {
     $response = $this->sut->instanceState('abc123', 'missing-job');
 
@@ -147,8 +135,6 @@ final class TugboatControllerTest extends KernelTestBase {
 
   /**
    * An unrecognized job type is a bug, not a state to render.
-   *
-   * @covers ::instanceState
    */
   public function testInstanceStateForUnknownJobType(): void {
     $this->expectException(\RuntimeException::class);
@@ -161,8 +147,6 @@ final class TugboatControllerTest extends KernelTestBase {
    *
    * The progress page polls this endpoint; an exception page would be parsed
    * as JSON and polled into forever. A clean 502 lets the frontend back off.
-   *
-   * @covers ::instanceState
    */
   public function testInstanceStateMapsOtherClientErrors(): void {
     $response = $this->sut->instanceState('abc123', 'forbidden-job');
@@ -176,8 +160,6 @@ final class TugboatControllerTest extends KernelTestBase {
 
   /**
    * A network failure reaching Tugboat is also a 502, not an exception page.
-   *
-   * @covers ::instanceState
    */
   public function testInstanceStateMapsNetworkFailure(): void {
     $response = $this->sut->instanceState('abc123', 'unreachable-job');
@@ -191,8 +173,6 @@ final class TugboatControllerTest extends KernelTestBase {
 
   /**
    * Duplicate stage markers cannot push progress past 100.
-   *
-   * @covers ::instanceState
    */
   public function testInstanceStateProgressClampsAtHundred(): void {
     $data = Json::decode((string) $this->sut->instanceState('abc123', 'noisy-job')->getContent());
@@ -204,8 +184,6 @@ final class TugboatControllerTest extends KernelTestBase {
    *
    * Sandboxes are deleted two hours after creation; a permanently cached
    * "ready" response would keep redirecting users to a dead preview.
-   *
-   * @covers ::instanceState
    */
   public function testInstanceStatePreviewMaxAgeIsFinite(): void {
     $response = $this->sut->instanceState('abc123', 'finished-job');

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/TugboatHooksTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/TugboatHooksTest.php
@@ -4,13 +4,18 @@ namespace Drupal\Tests\simplytest_tugboat\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\simplytest_tugboat\LaunchRecorder;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Covers the module's schema and update hooks.
- *
- * @group simplytest
- * @group simplytest_tugboat
  */
+#[CoversFunction('simplytest_tugboat_schema')]
+#[CoversFunction('simplytest_tugboat_update_10001')]
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
+#[RunTestsInSeparateProcesses]
 final class TugboatHooksTest extends KernelTestBase {
 
   protected static $modules = [
@@ -26,9 +31,6 @@ final class TugboatHooksTest extends KernelTestBase {
     $this->container->get('module_handler')->loadInclude('simplytest_tugboat', 'install');
   }
 
-  /**
-   * @covers ::simplytest_tugboat_schema
-   */
   public function testSchemaDefinition(): void {
     $schema = simplytest_tugboat_schema();
 
@@ -56,8 +58,6 @@ final class TugboatHooksTest extends KernelTestBase {
    * hook_schema() only runs when a module is first installed, so without this
    * the production database never gets the table and every launch is logged as
    * a recording failure.
-   *
-   * @covers ::simplytest_tugboat_update_10001
    */
   public function testUpdateInstallsTheTable(): void {
     $schema = $this->container->get('database')->schema();
@@ -70,8 +70,6 @@ final class TugboatHooksTest extends KernelTestBase {
 
   /**
    * Running the update twice is harmless.
-   *
-   * @covers ::simplytest_tugboat_update_10001
    */
   public function testUpdateIsIdempotent(): void {
     simplytest_tugboat_update_10001();

--- a/web/modules/custom/simplytest_tugboat/tests/src/Unit/BasePreviewConfigTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Unit/BasePreviewConfigTest.php
@@ -8,15 +8,22 @@ use Drupal\simplytest_ocd\OneClickDemoInterface;
 use Drupal\simplytest_ocd\OneClickDemoPluginManager;
 use Drupal\simplytest_tugboat\PreviewConfigGenerator;
 use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Covers the config a base preview is built from.
  *
- * @group simplytest
- * @group simplytest_tugboat
  *
- * @coversDefaultClass \Drupal\simplytest_tugboat\PreviewConfigGenerator
  */
+#[CoversClass(PreviewConfigGenerator::class)]
+#[CoversMethod(PreviewConfigGenerator::class, 'basePreview')]
+#[CoversMethod(PreviewConfigGenerator::class, 'generate')]
+#[CoversMethod(PreviewConfigGenerator::class, 'majorVersionFromBaseName')]
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
 final class BasePreviewConfigTest extends UnitTestCase {
 
   private PreviewConfigGenerator $sut;
@@ -38,10 +45,8 @@ final class BasePreviewConfigTest extends UnitTestCase {
 
   /**
    * A base only has an init stage, on the images its sandboxes use.
-   *
-   * @covers ::basePreview
-   * @dataProvider baseImages
    */
+  #[DataProvider('baseImages')]
   public function testImagesMatchTheSandboxConfig(string $name, string $php, string $mysql): void {
     $config = $this->sut->basePreview($name);
 
@@ -69,8 +74,6 @@ final class BasePreviewConfigTest extends UnitTestCase {
 
   /**
    * The init stage carries what every sandbox build used to repeat.
-   *
-   * @covers ::basePreview
    */
   public function testInitCommands(): void {
     $init = $this->sut->basePreview('drupal10')['services']['php']['commands']['init'];
@@ -93,8 +96,6 @@ final class BasePreviewConfigTest extends UnitTestCase {
 
   /**
    * Each release line's base holds a project at its newest release.
-   *
-   * @covers ::basePreview
    */
   public function testProjectPerReleaseLine(): void {
     $init = static fn (array $config): string => implode("\n", $config['services']['php']['commands']['init']);
@@ -109,8 +110,6 @@ final class BasePreviewConfigTest extends UnitTestCase {
 
   /**
    * A demo's base is the installed demo, so a launch can clone it.
-   *
-   * @covers ::basePreview
    */
   public function testDemoBaseIsTheInstalledDemo(): void {
     $init = $this->sut->basePreview('umami')['services']['php']['commands']['init'];
@@ -122,9 +121,6 @@ final class BasePreviewConfigTest extends UnitTestCase {
     self::assertGreaterThan(array_search('rm -rf "${DOCROOT}"', $init, TRUE), array_search('drush si demo_umami', $init, TRUE));
   }
 
-  /**
-   * @covers ::basePreview
-   */
   public function testUnknownBaseIsRefused(): void {
     $this->expectException(\InvalidArgumentException::class);
     $this->sut->basePreview('nonsense');
@@ -132,8 +128,6 @@ final class BasePreviewConfigTest extends UnitTestCase {
 
   /**
    * A sandbox reuses the base's project when it holds the requested release.
-   *
-   * @covers ::generate
    */
   public function testSandboxReusesBaseProject(): void {
     $build = $this->sut->generate([
@@ -160,9 +154,6 @@ final class BasePreviewConfigTest extends UnitTestCase {
     self::assertContains('cd "${TUGBOAT_ROOT}/stm" && composer require --dev --no-install drupal/core:11.2.2', $build);
   }
 
-  /**
-   * @covers ::majorVersionFromBaseName
-   */
   public function testMajorVersionFromBaseName(): void {
     self::assertEquals(10, PreviewConfigGenerator::majorVersionFromBaseName('drupal10'));
     self::assertEquals(7, PreviewConfigGenerator::majorVersionFromBaseName('drupal7'));

--- a/web/modules/custom/simplytest_tugboat/tests/src/Unit/Drupal10ConfigTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Unit/Drupal10ConfigTest.php
@@ -3,14 +3,13 @@
 namespace Drupal\Tests\simplytest_tugboat\Unit;
 
 use Drupal\Component\Utility\Crypt;
-use Drupal\simplytest_projects\ProjectTypes;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests Drupal 9 preview config.
- *
- * @group simplytest
- * @group simplytest_tugboat
  */
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
 final class Drupal10ConfigTest extends TugboatConfigTestBase {
 
   /**

--- a/web/modules/custom/simplytest_tugboat/tests/src/Unit/Drupal7ConfigTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Unit/Drupal7ConfigTest.php
@@ -4,13 +4,13 @@ namespace Drupal\Tests\simplytest_tugboat\Unit;
 
 use Drupal\Component\Utility\Crypt;
 use Drupal\simplytest_projects\ProjectTypes;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests Drupal 7 preview config.
- *
- * @group simplytest
- * @group simplytest_tugboat
  */
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
 final class Drupal7ConfigTest extends TugboatConfigTestBase {
 
   /**

--- a/web/modules/custom/simplytest_tugboat/tests/src/Unit/Drupal8ConfigTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Unit/Drupal8ConfigTest.php
@@ -4,13 +4,13 @@ namespace Drupal\Tests\simplytest_tugboat\Unit;
 
 use Drupal\Component\Utility\Crypt;
 use Drupal\simplytest_projects\ProjectTypes;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests Drupal 8 preview config.
- *
- * @group simplytest
- * @group simplytest_tugboat
  */
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
 final class Drupal8ConfigTest extends TugboatConfigTestBase {
 
   /**

--- a/web/modules/custom/simplytest_tugboat/tests/src/Unit/Drupal9ConfigTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Unit/Drupal9ConfigTest.php
@@ -4,13 +4,13 @@ namespace Drupal\Tests\simplytest_tugboat\Unit;
 
 use Drupal\Component\Utility\Crypt;
 use Drupal\simplytest_projects\ProjectTypes;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests Drupal 9 preview config.
- *
- * @group simplytest
- * @group simplytest_tugboat
  */
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
 final class Drupal9ConfigTest extends TugboatConfigTestBase {
 
   /**

--- a/web/modules/custom/simplytest_tugboat/tests/src/Unit/InstanceManagerTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Unit/InstanceManagerTest.php
@@ -63,21 +63,21 @@ final class InstanceManagerTest extends UnitTestCase {
     // LaunchRecorder is final, so it cannot be mocked. It swallows any
     // database failure, so mocked dependencies keep it out of the way.
     $launch_recorder = new LaunchRecorder(
-      $this->createMock(Connection::class),
-      $this->createMock(TimeInterface::class),
+      $this->createStub(Connection::class),
+      $this->createStub(TimeInterface::class),
       new NullLogger(),
-      $this->createMock(CacheTagsInvalidatorInterface::class)
+      $this->createStub(CacheTagsInvalidatorInterface::class)
     );
 
     $this->instanceManager = new InstanceManager(
       $config_factory,
       new LoggerChannel('foo'),
-      $this->createMock(ModuleHandlerInterface::class),
+      $this->createStub(ModuleHandlerInterface::class),
       $this->tugboatClient,
       $preview_config_generator,
       $launch_recorder,
       $base_previews,
-      $this->createMock(TimeInterface::class),
+      $this->createStub(TimeInterface::class),
     );
   }
 
@@ -245,7 +245,7 @@ final class InstanceManagerTest extends UnitTestCase {
     ]);
   }
 
-  public function testPanopoly() {
+  public function testPanopoly(): never {
     $this->markTestIncomplete('Weird issues afoot, like missing pathauto and ctools dependency');
     $this->doTest([
       'manualInstall' => FALSE,

--- a/web/modules/custom/simplytest_tugboat/tests/src/Unit/LaunchRecorderErrorTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Unit/LaunchRecorderErrorTest.php
@@ -8,23 +8,26 @@ use Drupal\Core\Database\Connection;
 use Drupal\simplytest_tugboat\LaunchRecord;
 use Drupal\simplytest_tugboat\LaunchRecorder;
 use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\Log\LoggerInterface;
 
 /**
  * A broken analytics write must not break launching.
  *
- * @group simplytest
- * @group simplytest_tugboat
  *
- * @coversDefaultClass \Drupal\simplytest_tugboat\LaunchRecorder
  */
+#[CoversClass(LaunchRecorder::class)]
+#[CoversMethod(LaunchRecorder::class, 'recordLaunch')]
+#[CoversMethod(LaunchRecorder::class, 'write')]
+#[CoversMethod(LaunchRecorder::class, 'recordFailure')]
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
 final class LaunchRecorderErrorTest extends UnitTestCase {
 
   /**
    * Nothing was written, so nothing rendered from the table is stale either.
-   *
-   * @covers ::recordLaunch
-   * @covers ::write
    */
   public function testInsertFailureIsLoggedNotThrown(): void {
     $database = $this->createMock(Connection::class);
@@ -68,9 +71,6 @@ final class LaunchRecorderErrorTest extends UnitTestCase {
 
   /**
    * A failed one click demo is named by its plugin ID in the log.
-   *
-   * @covers ::recordFailure
-   * @covers ::write
    */
   public function testOneClickDemoFailureIsLoggedByPluginId(): void {
     $database = $this->createMock(Connection::class);
@@ -89,7 +89,7 @@ final class LaunchRecorderErrorTest extends UnitTestCase {
         ['@project' => 'umami', '@message' => 'nope']
       );
 
-    $invalidator = $this->createMock(CacheTagsInvalidatorInterface::class);
+    $invalidator = $this->createStub(CacheTagsInvalidatorInterface::class);
     $recorder = new LaunchRecorder($database, $time, $logger, $invalidator);
     $recorder->recordFailure(LaunchRecord::forOneClickDemo('umami'));
   }

--- a/web/modules/custom/simplytest_tugboat/tests/src/Unit/PatchesFileTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Unit/PatchesFileTest.php
@@ -6,13 +6,13 @@ use Drupal\simplytest_ocd\OneClickDemoPluginManager;
 use Drupal\simplytest_projects\ProjectTypes;
 use Drupal\simplytest_tugboat\PreviewConfigGenerator;
 use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the patches.json handed to composer-patches.
- *
- * @group simplytest
- * @group simplytest_tugboat
  */
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
 final class PatchesFileTest extends UnitTestCase {
 
   /**
@@ -241,7 +241,7 @@ final class PatchesFileTest extends UnitTestCase {
    */
   private function getBuildCommands(array $overrides): array {
     $generator = new PreviewConfigGenerator(
-      $this->createMock(OneClickDemoPluginManager::class)
+      $this->createStub(OneClickDemoPluginManager::class)
     );
     $config = $generator->generate($overrides + [
       'perform_install' => TRUE,

--- a/web/modules/custom/simplytest_tugboat/tests/src/Unit/TugboatConfigTestBase.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Unit/TugboatConfigTestBase.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\simplytest_tugboat\Unit;
 use Drupal\simplytest_ocd\OneClickDemoPluginManager;
 use Drupal\simplytest_tugboat\PreviewConfigGenerator;
 use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Base test class for testing Tugboat configuration generation.
@@ -30,16 +31,15 @@ abstract class TugboatConfigTestBase extends UnitTestCase {
   protected function setUp(): void {
     parent::setUp();
     $this->previewConfigGenerator = new PreviewConfigGenerator(
-      $this->createMock(OneClickDemoPluginManager::class)
+      $this->createStub(OneClickDemoPluginManager::class)
     );
   }
 
   /**
    * @param array $parameters
    * @param array $expected_config
-   *
-   * @dataProvider configData
    */
+  #[DataProvider('configData')]
   public function testConfigData(array $parameters, array $expected_config) {
     $generated_config = $this->previewConfigGenerator->generate($parameters);
     self::assertEquals([

--- a/web/profiles/simplytest/simplytest.install
+++ b/web/profiles/simplytest/simplytest.install
@@ -8,7 +8,6 @@
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\simplytest_projects\CoreVersionManager;
 use Drupal\user\Entity\User;
-use Drupal\shortcut\Entity\Shortcut;
 
 /**
  * Implements hook_install_tasks().


### PR DESCRIPTION
Second of a two-PR stack, on top of [#642](https://github.com/simplytestme/website/pull/642). Almost entirely `vendor/bin/rector` output.

Clears the two deprecations left over from the Drupal 11 upgrade ([#641](https://github.com/simplytestme/website/pull/641)). Neither was a Drupal 11 blocker; both bite at Drupal 12 / PHPUnit 12.

## What Rector applied

- **`#[RunTestsInSeparateProcesses]` on 31 kernel test classes.** Drupal 11.3 deprecated kernel tests without it and Drupal 12 throws. `PhpUnitAddRunTestsInSeparateProcessesAttributeRector` stamps `KernelTestBase` and `BrowserTestBase` subclasses and leaves `UnitTestCase` alone — verified: the unit tests are untouched.
- **Doc-comment metadata becomes attributes.** `@group`, `@covers`, `@coversDefaultClass`, `@dataProvider` and `@depends` → `#[Group]`, `#[CoversClass]`, `#[CoversMethod]`, `#[DataProvider]`, `#[Depends]`. That's where the 2,236 PHPUnit deprecations came from; the suite now reports **0**.
- Five unused imports removed, and `PatchesUrlConstraintValidator::validate()`'s `$value` typed as `mixed`, matching the Symfony interface. Two baseline entries went stale as a result and are deleted.

## What I did by hand

Only formatting Rector doesn't do: `use` statements sorted back into alphabetical order after Rector prepends new ones, so the blocks stay Drupal-style. Rector itself shortened the fully-qualified names inside the attributes once it was allowed to import them.

## CI

The `rector` job ran `vendor/bin/rector` without `--dry-run`, so it rewrote the runner's checkout and always exited 0 — it was never actually gating. Now `--dry-run`, which is only possible because the tree is finally Rector-clean.

## On the cost of process isolation

Isolation makes every test method pay its own bootstrap, so this deserved measuring rather than guessing. Per module, back to back:

| | without | with |
|---|---|---|
| `simplytest_launch` (22 tests) | 89s | 97s |
| `simplytest_ocd` (9 tests) | 29.5s | 26.2s |
| one kernel class alone (3 tests) | 9.7s | 9.4s |

So roughly **+10% on the heaviest module** and nothing measurable elsewhere — a single class is unchanged because the bootstrap already dominates.

Full-suite wall clock in ddev turned out to be a bad instrument: two runs of the *identical* tree came in at 10m10s and 5m23s, so I'm quoting the controlled per-module numbers instead. For what it's worth, branch A measured 4m53s and this branch's best run 5m23s, consistent with the ~10%.

## Verification

- `phpunit`: **286 tests, 937 assertions, green**. PHPUnit deprecations 2,236 → **0**.
- `phpstan` level 6: **no errors**.
- `rector --dry-run`: **clean**, which is what lets CI gate on it.

The one remaining runtime deprecation is `Drush\Commands\DrushCommands::currentState()`, which is vendor code, not ours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)