### PR TITLE
Export two config files in the order Drupal writes them

### DIFF
--- a/config/sync/http_cache_control.settings.yml
+++ b/config/sync/http_cache_control.settings.yml
@@ -6,10 +6,10 @@ cache:
     404_max_age: 900
     302_max_age: 3600
     301_max_age: 3600
-    5xx_max_age: 0
     stale_while_revalidate: 0
     stale_if_error: 0
     vary: ''
+    5xx_max_age: 0
   surrogate:
     maxage: 0
     nostore: null

--- a/config/sync/lagoon_logs.settings.yml
+++ b/config/sync/lagoon_logs.settings.yml
@@ -1,6 +1,6 @@
 _core:
   default_config_hash: 2vFUGgSwVm06QF3OfOLUwxfBHxOrBOhydXlHcJEpHuw
+disable: 0
 host: application-logs.lagoon.svc
 port: 5140
 identifier: drupal
-disable: 0


### PR DESCRIPTION
Unblocks the `config:status` job, which is currently red on every pull request — including both PRs in the drupal-rector stack ([#642](https://github.com/simplytestme/website/pull/642), [#643](https://github.com/simplytestme/website/pull/643)).

## What's wrong

Two `config/sync` files hold their keys in an order Drupal no longer writes. A fresh Drupal 11 install puts `5xx_max_age` after `vary`, and `lagoon_logs`' `disable` before `host`. The order in git predates that.

Drupal itself does not consider this a difference:

```
$ drush config:status
[notice] No differences between DB and sync directory.

$ drush config:import --no
[notice] There are no changes to import.
```

But the job gates on `drush config:import --diff --no`, which renders the sync directory and the active config as **text**. Key order shows up there, the prompt fires, `--no` answers it, and drush exits 1.

## Why it only started failing now

The job installs `main`, swaps in the pull request, runs `updatedb`, then diffs. While `main` was Drupal 10 the install reproduced the historical order and the text matched. Now that `main` is Drupal 11 ([#641](https://github.com/simplytestme/website/pull/641)), the install writes the current order and the text does not.

## The fix

Taken straight from `drush config:export` on a clean install — that rewrites every file from active config, rather than only the ones whose *data* changed, which is why a normal export never corrected this. Afterwards `config/sync` is byte-identical to what an install produces.

**No setting changes**, only line order:

```diff
     301_max_age: 3600
-    5xx_max_age: 0
     stale_while_revalidate: 0
     stale_if_error: 0
     vary: ''
+    5xx_max_age: 0
```

## The alternative I didn't take

The job could gate on `drush config:import --no` (or `config:status`) instead, which compares decoded data and is immune to key-order noise, keeping `--diff` purely for display. That's arguably more robust, but it changes the semantics of a gate that otherwise works, and it would hide this drift rather than correct it. Worth doing if key-order noise recurs; two reordered lines are the smaller fix today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)