### PR TITLE
Report when a base preview stops building

### DIFF
--- a/docs/tugboat.md
+++ b/docs/tugboat.md
@@ -49,6 +49,25 @@ a day and deletes a replaced base once no sandbox builds on it anymore. A build
 that fails is deleted and retried on the next cycle, and launches keep using
 the previous base in the meantime.
 
+## Knowing when one breaks
+
+The daily rebuild is the only thing that runs a one click demo's install
+commands end to end, which makes it the smoke test for them. Every cron run
+reports on the bases first, before the pruner deletes the evidence, and logs an
+error on the `simplytest_tugboat` channel when a base is:
+
+- **failed** — the newest build failed, and launches are running on the one
+  before it,
+- **missing** — nothing carrying the name can be built on, so launches build
+  from scratch and fail the way the build did,
+- **stale** — no newer base has replaced it in two rebuild cycles, so the
+  rebuild has stopped finishing.
+
+A base is reported once per rebuild cycle, unless what is wrong with it
+changes, so a base that stays broken does not fill the log. Tugboat itself
+cannot report this: it has no outbound notification for a failed build, and the
+bases are not built from pull requests, so there is no provider status to fail.
+
 To inspect or rebuild them by hand:
 
 ```bash

--- a/web/modules/custom/simplytest_tugboat/simplytest_tugboat.module
+++ b/web/modules/custom/simplytest_tugboat/simplytest_tugboat.module
@@ -32,6 +32,11 @@ function simplytest_tugboat_cron(): void {
   $state = \Drupal::state();
   $now = \Drupal::time()->getRequestTime();
 
+  // Reported before pruning: deleting a failed build takes the only evidence
+  // that it failed with it.
+  \Drupal::service('simplytest_tugboat.base_preview_health')
+    ->report(SIMPLYTEST_TUGBOAT_BASE_PREVIEW_LIFETIME);
+
   $base_previews->prune();
 
   $rebuilt = (int) $state->get(SIMPLYTEST_TUGBOAT_BASE_PREVIEWS_REBUILT, 0);

--- a/web/modules/custom/simplytest_tugboat/simplytest_tugboat.services.yml
+++ b/web/modules/custom/simplytest_tugboat/simplytest_tugboat.services.yml
@@ -21,6 +21,14 @@ services:
       - '@simplytest_tugboat.preview_config_generator'
       - '@plugin.manager.oneclickdemo'
       - '@logger.channel.simplytest_tugboat'
+  simplytest_tugboat.base_preview_health:
+    class: Drupal\simplytest_tugboat\BasePreviewHealth
+    arguments:
+      - '@simplytest_tugboat.base_preview_manager'
+      - '@state'
+      - '@datetime.time'
+      - '@date.formatter'
+      - '@logger.channel.simplytest_tugboat'
   simplytest_tugboat.preview_config_generator:
     class: Drupal\simplytest_tugboat\PreviewConfigGenerator
     arguments: ['@plugin.manager.oneclickdemo']

--- a/web/modules/custom/simplytest_tugboat/src/BasePreviewHealth.php
+++ b/web/modules/custom/simplytest_tugboat/src/BasePreviewHealth.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\simplytest_tugboat;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\State\StateInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Reports on how the base previews are holding up.
+ *
+ * The daily rebuild is the only thing that runs a one click demo's install
+ * commands end to end, which makes it the site's smoke test for them. Nothing
+ * looked at the result: a build that fails is deleted by the pruner and
+ * retried the next day, so a demo that stops building degrades quietly until
+ * someone launches it and watches the build fail. This turns that into a log
+ * entry, which is the only place an operator can be told from.
+ *
+ * The check runs before the pruner, because deleting a failed build takes the
+ * only evidence that it failed with it. What is left after that is still
+ * caught: a base nothing has replaced in two cycles is stale, and a base with
+ * no usable build at all is missing.
+ *
+ * @phpstan-import-type Preview from BasePreviewManager
+ */
+final readonly class BasePreviewHealth {
+
+  /**
+   * The state key holding the last report per base name.
+   */
+  private const string REPORTED = 'simplytest_tugboat.base_preview_health_reported';
+
+  /**
+   * Preview states that mean the build did not finish.
+   */
+  private const array FAILED_STATES = ['failed', 'cancelled'];
+
+  public function __construct(
+    private BasePreviewManager $basePreviews,
+    private StateInterface $state,
+    private TimeInterface $time,
+    private DateFormatterInterface $dateFormatter,
+    private LoggerInterface $logger,
+  ) {
+  }
+
+  /**
+   * Logs an error for every base that sandboxes cannot rely on.
+   *
+   * @param int $lifetime
+   *   How long a set of bases is used before it is rebuilt. A base that no
+   *   newer one has replaced in two of those has stopped rebuilding. A base
+   *   is reported at most once per lifetime, unless what is wrong with it
+   *   changes, so a base that stays broken does not fill the log.
+   *
+   * @return array<string, \Drupal\simplytest_tugboat\BasePreviewStatus>
+   *   The status of every base, keyed by base name.
+   */
+  public function report(int $lifetime): array {
+    $now = $this->time->getRequestTime();
+    /** @var array<string, array{status: string, time: int}> $reported */
+    $reported = $this->state->get(self::REPORTED, []);
+    $statuses = [];
+
+    foreach ($this->basePreviews->inventory() as $name => $previews) {
+      $usable = BasePreviewManager::usableIn($previews);
+      $status = $this->statusOf($previews, $usable, $now, $lifetime * 2);
+      $statuses[$name] = $status;
+
+      if ($status === BasePreviewStatus::Ok) {
+        unset($reported[$name]);
+        continue;
+      }
+      $previous = $reported[$name] ?? NULL;
+      if ($previous !== NULL && $previous['status'] === $status->value && $now - $previous['time'] < $lifetime) {
+        continue;
+      }
+      $reported[$name] = ['status' => $status->value, 'time' => $now];
+      $this->log($name, $status, $this->ageOf($usable, $now));
+    }
+
+    $this->state->set(self::REPORTED, $reported);
+    return $statuses;
+  }
+
+  /**
+   * Judges one base from its previews, newest first.
+   *
+   * @param list<Preview> $previews
+   *   Every preview carrying the base name.
+   * @param Preview|null $usable
+   *   The newest preview a sandbox could build on, if there is one.
+   */
+  private function statusOf(array $previews, ?array $usable, int $now, int $stale_after): BasePreviewStatus {
+    if ($usable === NULL) {
+      return BasePreviewStatus::Missing;
+    }
+    // The newest build having failed says the rebuild is broken now, even
+    // though an older base is keeping launches working.
+    if (in_array($previews[0]['state'], self::FAILED_STATES, TRUE)) {
+      return BasePreviewStatus::Failed;
+    }
+    $age = $this->ageOf($usable, $now);
+    if ($age !== NULL && $age > $stale_after) {
+      return BasePreviewStatus::Stale;
+    }
+    return BasePreviewStatus::Ok;
+  }
+
+  /**
+   * The age of a preview in seconds, or NULL without a usable timestamp.
+   *
+   * @param Preview|null $preview
+   *   The preview to measure.
+   */
+  private function ageOf(?array $preview, int $now): ?int {
+    if ($preview === NULL) {
+      return NULL;
+    }
+    $created = strtotime($preview['createdAt']);
+    return $created === FALSE ? NULL : $now - $created;
+  }
+
+  private function log(string $name, BasePreviewStatus $status, ?int $age): void {
+    $message = match ($status) {
+      BasePreviewStatus::Missing => 'Base preview @name has no usable build. Sandboxes and one click demos for it build from scratch, and fail the same way the build did.',
+      BasePreviewStatus::Failed => 'The latest build of base preview @name failed. Launches keep using the base built @age ago until the next rebuild succeeds.',
+      BasePreviewStatus::Stale => 'Base preview @name has not been replaced in @age. Its rebuild is not finishing.',
+      BasePreviewStatus::Ok => throw new \LogicException('A healthy base preview is not reported.'),
+    };
+    $this->logger->error($message, [
+      '@name' => $name,
+      '@age' => $age === NULL ? 'an unknown time' : $this->dateFormatter->formatInterval($age),
+    ]);
+  }
+
+}

--- a/web/modules/custom/simplytest_tugboat/src/BasePreviewManager.php
+++ b/web/modules/custom/simplytest_tugboat/src/BasePreviewManager.php
@@ -92,7 +92,7 @@ final readonly class BasePreviewManager {
    *   The preview ID, or NULL when no usable base exists.
    */
   public function findUsable(string $name): ?string {
-    return self::usableIn($this->previewsNamed($name, $this->allPreviews()));
+    return self::usableIn($this->previewsNamed($name, $this->allPreviews()))['id'] ?? NULL;
   }
 
   /**
@@ -159,7 +159,7 @@ final readonly class BasePreviewManager {
     $all = $this->allPreviews();
     foreach ($this->names() as $name) {
       $previews = $this->previewsNamed($name, $all);
-      $current = self::usableIn($previews);
+      $current = self::usableIn($previews)['id'] ?? NULL;
       foreach ($previews as $preview) {
         if ($preview['id'] === $current) {
           continue;
@@ -221,11 +221,13 @@ final readonly class BasePreviewManager {
    * The newest usable preview in a list sorted newest first.
    *
    * @param list<Preview> $previews
+   *
+   * @return Preview|null
    */
-  private static function usableIn(array $previews): ?string {
+  public static function usableIn(array $previews): ?array {
     foreach ($previews as $preview) {
       if (!in_array($preview['state'], self::UNUSABLE_STATES, TRUE)) {
-        return $preview['id'];
+        return $preview;
       }
     }
     return NULL;

--- a/web/modules/custom/simplytest_tugboat/src/BasePreviewStatus.php
+++ b/web/modules/custom/simplytest_tugboat/src/BasePreviewStatus.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\simplytest_tugboat;
+
+/**
+ * How a base preview is holding up.
+ */
+enum BasePreviewStatus: string {
+
+  /**
+   * A usable base exists and a newer one replaced it within the last cycle.
+   */
+  case Ok = 'ok';
+
+  /**
+   * Nothing carrying the name can be built on, so builds start from scratch.
+   */
+  case Missing = 'missing';
+
+  /**
+   * The most recent build failed. An older base is still being built on.
+   */
+  case Failed = 'failed';
+
+  /**
+   * The base is usable, but nothing has replaced it in two rebuild cycles.
+   */
+  case Stale = 'stale';
+
+}

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/BasePreviewCronTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/BasePreviewCronTest.php
@@ -96,11 +96,26 @@ final class BasePreviewCronTest extends KernelTestBase {
     self::assertEquals($now, $state->get(SIMPLYTEST_TUGBOAT_BASE_PREVIEWS_REBUILT));
   }
 
+  /**
+   * Every run reports on the bases, whether or not it rebuilds them.
+   */
+  public function testCronReportsBasePreviewHealth(): void {
+    putenv('LAGOON_ENVIRONMENT_TYPE=production');
+    $logger = $this->container->get('simplytest_projects_test.logger');
+
+    simplytest_tugboat_cron();
+
+    self::assertTrue($logger->hasMessageContaining('Base preview starshot has no usable build.'));
+    // Reported before the pruner deleted the failed build it is about.
+    self::assertTrue($logger->hasMessageContaining('The latest build of base preview drupal10 failed.'));
+  }
+
   private function assertNothingHappened(): void {
     $state = $this->container->get('state');
     self::assertNull($state->get(self::CREATE_URL));
     self::assertNull($state->get('tugboat.deleted_previews'));
     self::assertNull($state->get(SIMPLYTEST_TUGBOAT_BASE_PREVIEWS_REBUILT));
+    self::assertNull($state->get('simplytest_tugboat.base_preview_health_reported'));
   }
 
 }

--- a/web/modules/custom/simplytest_tugboat/tests/src/Kernel/BasePreviewHealthTest.php
+++ b/web/modules/custom/simplytest_tugboat/tests/src/Kernel/BasePreviewHealthTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\simplytest_tugboat\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\simplytest_projects_test\BufferedLogger;
+use Drupal\simplytest_tugboat\BasePreviewHealth;
+use Drupal\simplytest_tugboat\BasePreviewStatus;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Covers the report on how the base previews are holding up.
+ */
+#[CoversClass(BasePreviewHealth::class)]
+#[Group('simplytest')]
+#[Group('simplytest_tugboat')]
+#[RunTestsInSeparateProcesses]
+final class BasePreviewHealthTest extends KernelTestBase {
+
+  /**
+   * A lifetime no preview in the mocked repository can outlive.
+   */
+  private const int TEN_YEARS = 315360000;
+
+  /**
+   * A lifetime every preview in the mocked repository has outlived.
+   */
+  private const int ONE_MINUTE = 60;
+
+  protected static $modules = [
+    'tugboat',
+    'simplytest_projects',
+    'simplytest_projects_test',
+    'simplytest_ocd',
+    'simplytest_tugboat',
+  ];
+
+  private BasePreviewHealth $sut;
+
+  private BufferedLogger $logger;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->config('tugboat.settings')
+      ->set('repository_id', 'kerneltestrepo')
+      ->save();
+    $this->sut = $this->container->get('simplytest_tugboat.base_preview_health');
+    $this->logger = $this->container->get('simplytest_projects_test.logger');
+  }
+
+  /**
+   * Every base is judged, and only the broken ones are logged.
+   */
+  public function testReportsWhatEachBaseIsDoing(): void {
+    $statuses = $this->sut->report(self::TEN_YEARS);
+
+    self::assertEquals([
+      // A suspended base is still a base.
+      'drupal7' => BasePreviewStatus::Ok,
+      // Its only build failed.
+      'drupal8' => BasePreviewStatus::Missing,
+      // The newest is still building, so the previous one is in use.
+      'drupal9' => BasePreviewStatus::Ok,
+      // The newest failed, and the previous one carries launches.
+      'drupal10' => BasePreviewStatus::Failed,
+      // Nothing on Tugboat carries the name.
+      'drupal11' => BasePreviewStatus::Missing,
+      'commerce' => BasePreviewStatus::Ok,
+      'starshot' => BasePreviewStatus::Missing,
+      'umami' => BasePreviewStatus::Ok,
+    ], $statuses);
+
+    // A one click demo with no base is the case this exists for: a demo that
+    // stops building leaves nothing to clone.
+    self::assertTrue($this->logger->hasMessageContaining('Base preview starshot has no usable build.'));
+    self::assertTrue($this->logger->hasMessageContaining('The latest build of base preview drupal10 failed.'));
+    // The message says what launches are running on in the meantime.
+    self::assertTrue($this->logger->hasMessageContaining('Launches keep using the base built 2 years'));
+    // A healthy base is not worth a word.
+    self::assertEquals(0, $this->countMessagesFor('drupal9'));
+    self::assertEquals(0, $this->countMessagesFor('umami'));
+  }
+
+  /**
+   * A base nothing has replaced in two cycles is reported.
+   */
+  public function testReportsBasesThatStoppedRebuilding(): void {
+    $statuses = $this->sut->report(self::ONE_MINUTE);
+
+    self::assertEquals(BasePreviewStatus::Stale, $statuses['umami']);
+    self::assertEquals(BasePreviewStatus::Stale, $statuses['drupal7']);
+    // A failed rebuild is the more useful thing to say about a base.
+    self::assertEquals(BasePreviewStatus::Failed, $statuses['drupal10']);
+    self::assertTrue($this->logger->hasMessageContaining('Base preview umami has not been replaced in 2 years'));
+  }
+
+  /**
+   * A base that stays broken is reported once a cycle, not once a cron run.
+   */
+  public function testReportsAProblemOncePerLifetime(): void {
+    $this->sut->report(self::TEN_YEARS);
+    self::assertEquals(1, $this->countMessagesFor('drupal10'));
+
+    $this->sut->report(self::TEN_YEARS);
+    self::assertEquals(1, $this->countMessagesFor('drupal10'));
+
+    // Unless what is wrong with it changes. Shortening the lifetime makes
+    // every usable base stale, which drupal7 was not a moment ago.
+    self::assertEquals(0, $this->countMessagesFor('drupal7'));
+    $this->sut->report(self::ONE_MINUTE);
+    self::assertEquals(1, $this->countMessagesFor('drupal7'));
+    // The failed one has not changed, and is still inside its lifetime.
+    self::assertEquals(1, $this->countMessagesFor('drupal10'));
+  }
+
+  /**
+   * A problem still there a lifetime later is reported again.
+   */
+  public function testReportsAgainOnTheNextLifetime(): void {
+    $this->sut->report(self::ONE_MINUTE);
+    self::assertEquals(1, $this->countMessagesFor('starshot'));
+
+    $state = $this->container->get('state');
+    $reported = $state->get('simplytest_tugboat.base_preview_health_reported');
+    $reported['starshot']['time'] -= self::ONE_MINUTE + 1;
+    $state->set('simplytest_tugboat.base_preview_health_reported', $reported);
+
+    $this->sut->report(self::ONE_MINUTE);
+    self::assertEquals(2, $this->countMessagesFor('starshot'));
+  }
+
+  /**
+   * A base that recovers is reported the next time it breaks.
+   */
+  public function testForgetsABaseThatRecovers(): void {
+    $this->sut->report(self::ONE_MINUTE);
+    self::assertEquals(1, $this->countMessagesFor('drupal7'));
+
+    // Healthy again, so nothing is held against it.
+    $this->sut->report(self::TEN_YEARS);
+    self::assertArrayNotHasKey(
+      'drupal7',
+      $this->container->get('state')->get('simplytest_tugboat.base_preview_health_reported'),
+    );
+
+    $this->sut->report(self::ONE_MINUTE);
+    self::assertEquals(2, $this->countMessagesFor('drupal7'));
+  }
+
+  /**
+   * How many log messages name a base.
+   */
+  private function countMessagesFor(string $name): int {
+    $messages = array_filter(
+      $this->logger->getMessages(),
+      static fn (string $message): bool => str_contains($message, "preview $name "),
+    );
+    return count($messages);
+  }
+
+}


### PR DESCRIPTION
## What

Cron now checks how the base previews are holding up and logs an error when one is not in a state launches can rely on. Nothing about the launch path changes.

## Why

The daily base preview rebuild is the only thing that runs a one click demo's install commands end to end, which makes it the site's smoke test for them. Nothing looked at the result. A build that fails is deleted by the pruner and retried the next day, so a demo that stops building — an upstream `composer create-project` breaking, a recipe changing — degrades quietly until someone launches it and watches the build fail.

Tugboat cannot report this for us. Its `webhook` field is inbound, the Slack integration is a `curl` inside a lifecycle hook that a failed build never reaches, and the bases are API-created rather than built from pull requests, so there is no provider status to go red.

## How

`BasePreviewHealth` judges each base from the inventory and reports one of three problems:

- **failed** — the newest build failed, and launches are running on the one before it
- **missing** — nothing carrying the name can be built on, so launches build from scratch and fail the way the build did
- **stale** — no newer base has replaced it in two rebuild cycles

Two things shape the implementation:

- It runs **before** `prune()`. Deleting a failed build takes the only evidence that it failed with it, so checking afterwards would see nothing. `missing` and `stale` are the durable backstops.
- A base is reported **once per rebuild cycle**, unless what is wrong with it changes. Cron runs every 30 minutes, so an unthrottled check would write 48 identical errors a day per broken base.

`BasePreviewManager::usableIn()` is now public and returns the preview rather than its ID, so the health check reuses the existing definition of "usable" instead of restating it.

The log entries are the delivery mechanism, so this pairs with the Sentry work: with `raven` reporting error-level watchdog entries, a demo that stops building becomes an alert rather than a line in dblog nobody reads.

## Testing notes

Five kernel tests cover the statuses against the mocked Tugboat repository, the once-per-cycle throttle, re-reporting on the next cycle, and a base that recovers. `BasePreviewCronTest` asserts cron reports before pruning. PHPUnit, PHPStan, and Rector are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
