### PR TITLE
Report errors to Sentry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "drupal/purge": "^3.0",
         "drupal/queue_unique": "^4.0",
         "drupal/tugboat": "^1.0@alpha",
-        "drush/drush": "^13"
+        "drush/drush": "^13",
+        "sentry/sentry": "^4.31"
     },
     "require-dev": {
         "drupal/core-dev": "^11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "254855ee0f9e720e2298b39d7ae58689",
+    "content-hash": "64d18246adfbbfb18f7e694753bc9e83",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -2526,6 +2526,66 @@
             "time": "2026-08-24T09:13:11+00:00"
         },
         {
+            "name": "jean85/pretty-package-versions",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Jean85/pretty-package-versions.git",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.1.0",
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "jean85/composer-provided-replaced-stub-package": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^7.5|^8.5|^9.6",
+                "rector/rector": "^2.0",
+                "vimeo/psalm": "^4.3 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jean85\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alessandro Lai",
+                    "email": "alessandro.lai85@gmail.com"
+                }
+            ],
+            "description": "A library to get pretty versions strings of installed dependencies",
+            "keywords": [
+                "composer",
+                "package",
+                "release",
+                "versions"
+            ],
+            "support": {
+                "issues": "https://github.com/Jean85/pretty-package-versions/issues",
+                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
+            },
+            "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
             "name": "justinrainbow/json-schema",
             "version": "6.8.2",
             "source": {
@@ -4127,6 +4187,102 @@
             "time": "2024-07-03T04:53:05+00:00"
         },
         {
+            "name": "sentry/sentry",
+            "version": "4.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/getsentry/sentry-php.git",
+                "reference": "39d9f86bd56c6cc6ae7b64c2b849f7f046d38394"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/39d9f86bd56c6cc6ae7b64c2b849f7f046d38394",
+                "reference": "39d9f86bd56c6cc6ae7b64c2b849f7f046d38394",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "guzzlehttp/psr7": "^1.8.4|^2.1.1|^3.0.0",
+                "jean85/pretty-package-versions": "^1.5|^2.0.4",
+                "php": "^7.2|^8.0",
+                "psr/log": "^1.0|^2.0|^3.0",
+                "symfony/options-resolver": "^4.4.30|^5.0.11|^6.0|^7.0|^8.0"
+            },
+            "conflict": {
+                "raven/raven": "*"
+            },
+            "require-dev": {
+                "carthage-software/mago": "1.30.0",
+                "friendsofphp/php-cs-fixer": "^3.4",
+                "guzzlehttp/guzzle": "^7.0|^8.0",
+                "guzzlehttp/promises": "^2.0.3|^3.0.0",
+                "monolog/monolog": "^1.6|^2.0|^3.0",
+                "nyholm/psr7": "^1.8",
+                "open-telemetry/api": "^1.1",
+                "open-telemetry/context": "^1.1",
+                "open-telemetry/exporter-otlp": "^1.1",
+                "open-telemetry/sdk": "^1.1",
+                "open-telemetry/sem-conv": "^1.27",
+                "phpstan/phpstan": "^1.3",
+                "phpunit/phpunit": "^8.5.52|^9.6.34",
+                "spiral/roadrunner-http": "^3.6",
+                "spiral/roadrunner-worker": "^3.6"
+            },
+            "suggest": {
+                "ext-excimer": "Enable Sentry profiling with the Excimer PHP extension.",
+                "monolog/monolog": "Allow sending log messages to Sentry by using the included Monolog handler."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Sentry\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sentry",
+                    "email": "accounts@sentry.io"
+                }
+            ],
+            "description": "PHP SDK for Sentry (http://sentry.io)",
+            "homepage": "http://sentry.io",
+            "keywords": [
+                "crash-reporting",
+                "crash-reports",
+                "error-handler",
+                "error-monitoring",
+                "log",
+                "logging",
+                "profiling",
+                "sentry",
+                "tracing"
+            ],
+            "support": {
+                "issues": "https://github.com/getsentry/sentry-php/issues",
+                "source": "https://github.com/getsentry/sentry-php/tree/4.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://sentry.io/",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://sentry.io/pricing/",
+                    "type": "custom"
+                }
+            ],
+            "time": "2026-08-27T12:59:01+00:00"
+        },
+        {
             "name": "symfony/console",
             "version": "v7.4.18",
             "source": {
@@ -5137,6 +5293,77 @@
                 }
             ],
             "time": "2026-08-22T09:04:42+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -39,6 +39,7 @@ module:
   simplytest_launch: 0
   simplytest_ocd: 0
   simplytest_projects: 0
+  simplytest_sentry: 0
   simplytest_tugboat: 0
   system: 0
   text: 0

--- a/docs/sentry.md
+++ b/docs/sentry.md
@@ -1,0 +1,55 @@
+# Sentry
+
+Errors are reported to Sentry so somebody finds out about them without reading
+logs. `simplytest_sentry` is the whole integration: one logger service, tagged
+`logger`, that forwards Drupal log messages at error level and above.
+
+## What it sends
+
+Only `error` and worse. Everything a sandbox does wrong on the way in is a
+warning or a notice, and `lagoon_logs` already ships all of it to Lagoon;
+Sentry is for the handful of things somebody has to go and fix.
+
+Each event carries:
+
+- the message with its placeholders filled in, as the title,
+- a `channel` tag, which is what to write alert rules against —
+  `simplytest_tugboat` covers launches and the base previews,
+- the scalar parts of the log context, including the placeholder values, as
+  extra data,
+- a fingerprint of the channel and the message *before* substitution.
+
+The fingerprint is the part worth knowing about. Sentry groups on what it is
+given, and these messages carry the values that made them: a base preview name,
+an age, a project. Grouping on the message template instead means one issue per
+thing that is wrong, rather than a new one each time it is reported.
+
+An exception in the context is sent as an exception, so Sentry builds a real
+trace from it, and only the rendered message goes along as extra data. The
+exception object itself is never serialized: it holds whatever it was thrown
+with, and an HTTP client error drags in the request, the response, and the
+handler stack behind it.
+
+## Configuration
+
+There is none, and no DSN in `config/sync`. The hub is built from the
+environment:
+
+| Variable | Falls back to | Effect |
+| --- | --- | --- |
+| `SENTRY_DSN` | — | Without it nothing is reported at all |
+| `SENTRY_ENVIRONMENT` | `LAGOON_ENVIRONMENT` | Which environment an issue came from |
+| `SENTRY_RELEASE` | `LAGOON_GIT_SHA` | Which deploy an issue came from |
+
+The variables are set on the production environment only, which is what keeps
+pull request environments and local installs out of the project:
+
+```bash
+lagoon add variable -p simplytest -e main -N SENTRY_DSN -V "https://…" -S runtime
+```
+
+Sentry's own error and exception handlers are removed at build time. Drupal
+logs PHP errors and uncaught exceptions itself and the logger sends those on,
+so leaving them installed would open a second issue for one problem. The fatal
+handler stays: a request that runs out of memory never reaches the logger, and
+that is the failure nobody finds out about otherwise.

--- a/web/modules/custom/simplytest_sentry/simplytest_sentry.info.yml
+++ b/web/modules/custom/simplytest_sentry/simplytest_sentry.info.yml
@@ -1,0 +1,5 @@
+name: 'SimplyTest Sentry'
+description: 'Forwards logged errors to Sentry.'
+type: module
+package: Simplytest
+core_version_requirement: ^11

--- a/web/modules/custom/simplytest_sentry/simplytest_sentry.services.yml
+++ b/web/modules/custom/simplytest_sentry/simplytest_sentry.services.yml
@@ -1,0 +1,11 @@
+services:
+  simplytest_sentry.hub:
+    class: Sentry\State\Hub
+    factory: ['Drupal\simplytest_sentry\SentryHubFactory', 'create']
+  logger.sentry:
+    class: Drupal\simplytest_sentry\Logger\SentryLogger
+    arguments:
+      - '@simplytest_sentry.hub'
+      - '@logger.log_message_parser'
+    tags:
+      - { name: logger }

--- a/web/modules/custom/simplytest_sentry/src/Logger/SentryLogger.php
+++ b/web/modules/custom/simplytest_sentry/src/Logger/SentryLogger.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\simplytest_sentry\Logger;
+
+use Drupal\Core\Logger\LogMessageParserInterface;
+use Drupal\Core\Logger\RfcLogLevel;
+use Drupal\Core\Logger\RfcLoggerTrait;
+use Psr\Log\LoggerInterface;
+use Sentry\Severity;
+use Sentry\State\HubInterface;
+use Sentry\State\Scope;
+
+/**
+ * Forwards logged errors to Sentry.
+ *
+ * Only errors and worse are sent. Everything a sandbox does wrong is a warning
+ * or a notice, and Lagoon Logs already keeps all of it; what belongs in Sentry
+ * is the handful of things somebody has to go and fix.
+ */
+final readonly class SentryLogger implements LoggerInterface {
+
+  use RfcLoggerTrait;
+
+  public function __construct(
+    private HubInterface $hub,
+    private LogMessageParserInterface $parser,
+  ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @param mixed $level
+   * @param array<string, mixed> $context
+   */
+  #[\Override]
+  public function log($level, \Stringable|string $message, array $context = []): void {
+    // Drupal hands loggers an RFC 5424 severity, where the lower number is the
+    // worse problem.
+    if (!is_int($level) || $level > RfcLogLevel::ERROR) {
+      return;
+    }
+
+    $template = (string) $message;
+    $rendered = $template;
+    // Takes both by reference: the placeholders it returns are the ones it
+    // removed from the context.
+    $placeholders = $this->parser->parseMessagePlaceholders($rendered, $context);
+    $rendered = strtr($rendered, $placeholders);
+
+    $channel = isset($context['channel']) && is_string($context['channel']) ? $context['channel'] : 'php';
+    $exception = $context['exception'] ?? NULL;
+    $extra = $this->scalars($context + $placeholders);
+    $severity = $level <= RfcLogLevel::CRITICAL ? Severity::fatal() : Severity::error();
+
+    $this->hub->withScope(function (Scope $scope) use ($channel, $template, $rendered, $extra, $exception, $severity): void {
+      // Sentry groups on what it is given, and a rendered message carries the
+      // values that made it: a base preview name, an age, a project. Grouping
+      // on the message before substitution keeps one issue per thing that is
+      // wrong, rather than a new one every time it is reported.
+      $scope->setFingerprint([$channel, $template]);
+      // The channel is what an alert rule can be written against.
+      $scope->setTag('channel', $channel);
+      $scope->setExtras($extra);
+
+      if ($exception instanceof \Throwable) {
+        $scope->setExtra('drupal_message', $rendered);
+        $this->hub->captureException($exception);
+        return;
+      }
+      $this->hub->captureMessage($rendered, $severity);
+    });
+  }
+
+  /**
+   * Drops everything from a context that is not worth serializing.
+   *
+   * Drupal's context carries the exception and, through it, whatever the
+   * exception holds: an HTTP client error drags in the request, the response,
+   * and the handler stack. Sending only scalars keeps one logged error from
+   * turning into a fatal inside the reporter.
+   *
+   * @param array<string, mixed> $values
+   *   The context to reduce.
+   *
+   * @return array<string, scalar>
+   *   Every scalar in it.
+   */
+  private function scalars(array $values): array {
+    return array_filter($values, is_scalar(...));
+  }
+
+}

--- a/web/modules/custom/simplytest_sentry/src/SentryHubFactory.php
+++ b/web/modules/custom/simplytest_sentry/src/SentryHubFactory.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\simplytest_sentry;
+
+use Sentry\ClientBuilder;
+use Sentry\Integration\ErrorListenerIntegration;
+use Sentry\Integration\ExceptionListenerIntegration;
+use Sentry\Integration\IntegrationInterface;
+use Sentry\State\Hub;
+use Sentry\State\HubInterface;
+
+/**
+ * Builds the Sentry hub the logger reports through.
+ *
+ * Everything comes from the environment, so no DSN is in configuration and no
+ * environment reports unless it was given one. Lagoon sets SENTRY_DSN on
+ * production only, which is what keeps sandboxes' own noise and every pull
+ * request environment out of the project.
+ */
+final class SentryHubFactory {
+
+  public static function create(): HubInterface {
+    $dsn = getenv('SENTRY_DSN');
+    if (!is_string($dsn) || $dsn === '') {
+      // A hub with no client drops everything it is given, so the logger does
+      // not have to know whether Sentry is configured.
+      return new Hub();
+    }
+    $client = ClientBuilder::create([
+      'dsn' => $dsn,
+      'environment' => self::env('SENTRY_ENVIRONMENT') ?? self::env('LAGOON_ENVIRONMENT'),
+      // Which deploy an error came from. Lagoon has the commit to hand.
+      'release' => self::env('SENTRY_RELEASE') ?? self::env('LAGOON_GIT_SHA'),
+      'integrations' => self::withoutDuplicateHandlers(...),
+    ])->getClient();
+    return new Hub($client);
+  }
+
+  /**
+   * Drops the integrations that would report what Drupal already logs.
+   *
+   * Drupal writes PHP errors and uncaught exceptions to the log itself, and
+   * the logger sends those on, so Sentry's own handlers for them would open a
+   * second issue for one problem. The fatal handler stays: a request that runs
+   * out of memory never reaches the logger, and that is the failure nobody
+   * finds out about otherwise.
+   *
+   * @param list<IntegrationInterface> $integrations
+   *   The default integrations.
+   *
+   * @return list<IntegrationInterface>
+   *   The ones to install.
+   */
+  private static function withoutDuplicateHandlers(array $integrations): array {
+    return array_values(array_filter(
+      $integrations,
+      static fn (IntegrationInterface $integration): bool => !$integration instanceof ErrorListenerIntegration
+        && !$integration instanceof ExceptionListenerIntegration,
+    ));
+  }
+
+  private static function env(string $name): ?string {
+    $value = getenv($name);
+    return is_string($value) && $value !== '' ? $value : NULL;
+  }
+
+}

--- a/web/modules/custom/simplytest_sentry/tests/src/Unit/RecordingTransport.php
+++ b/web/modules/custom/simplytest_sentry/tests/src/Unit/RecordingTransport.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\simplytest_sentry\Unit;
+
+use Sentry\Event;
+use Sentry\Transport\Result;
+use Sentry\Transport\ResultStatus;
+use Sentry\Transport\TransportInterface;
+
+/**
+ * Keeps the events a client sends, instead of sending them to Sentry.
+ */
+final class RecordingTransport implements TransportInterface {
+
+  /**
+   * @var list<\Sentry\Event>
+   */
+  private array $sent = [];
+
+  #[\Override]
+  public function send(Event $event): Result {
+    $this->sent[] = $event;
+    return new Result(ResultStatus::success(), $event);
+  }
+
+  #[\Override]
+  public function close(?int $timeout = NULL): Result {
+    return new Result(ResultStatus::success());
+  }
+
+  /**
+   * @return list<\Sentry\Event>
+   */
+  public function sent(): array {
+    return $this->sent;
+  }
+
+}

--- a/web/modules/custom/simplytest_sentry/tests/src/Unit/SentryHubFactoryTest.php
+++ b/web/modules/custom/simplytest_sentry/tests/src/Unit/SentryHubFactoryTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\simplytest_sentry\Unit;
+
+use Drupal\simplytest_sentry\SentryHubFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Sentry\Integration\ErrorListenerIntegration;
+use Sentry\Integration\ExceptionListenerIntegration;
+use Sentry\Integration\FatalErrorListenerIntegration;
+
+/**
+ * Covers the hub built from the environment.
+ */
+#[CoversClass(SentryHubFactory::class)]
+#[Group('simplytest')]
+#[Group('simplytest_sentry')]
+final class SentryHubFactoryTest extends TestCase {
+
+  private const string DSN = 'https://examplePublicKey@o0.ingest.sentry.io/0';
+
+  private const array VARIABLES = [
+    'SENTRY_DSN',
+    'SENTRY_ENVIRONMENT',
+    'SENTRY_RELEASE',
+    'LAGOON_ENVIRONMENT',
+    'LAGOON_GIT_SHA',
+  ];
+
+  protected function setUp(): void {
+    parent::setUp();
+    foreach (self::VARIABLES as $variable) {
+      putenv($variable);
+    }
+  }
+
+  protected function tearDown(): void {
+    foreach (self::VARIABLES as $variable) {
+      putenv($variable);
+    }
+    parent::tearDown();
+  }
+
+  /**
+   * Without a DSN nothing is reported, which is every environment but one.
+   */
+  public function testReportsNothingWithoutADsn(): void {
+    self::assertNull(SentryHubFactory::create()->getClient());
+
+    // An empty variable is the same as no variable: Lagoon hands one over on
+    // environments the value was never set for.
+    putenv('SENTRY_DSN=');
+    self::assertNull(SentryHubFactory::create()->getClient());
+  }
+
+  /**
+   * The environment and release come from the environment.
+   */
+  public function testTakesTheEnvironmentAndReleaseFromTheEnvironment(): void {
+    putenv('SENTRY_DSN=' . self::DSN);
+    putenv('SENTRY_ENVIRONMENT=production');
+    putenv('SENTRY_RELEASE=0123abc');
+
+    $client = SentryHubFactory::create()->getClient();
+
+    self::assertNotNull($client);
+    self::assertEquals('production', $client->getOptions()->getEnvironment());
+    self::assertEquals('0123abc', $client->getOptions()->getRelease());
+  }
+
+  /**
+   * Lagoon already says which environment and which deploy this is.
+   */
+  public function testFallsBackToWhatLagoonSets(): void {
+    putenv('SENTRY_DSN=' . self::DSN);
+    putenv('LAGOON_ENVIRONMENT=main');
+    putenv('LAGOON_GIT_SHA=0123abc');
+
+    $client = SentryHubFactory::create()->getClient();
+
+    self::assertNotNull($client);
+    self::assertEquals('main', $client->getOptions()->getEnvironment());
+    self::assertEquals('0123abc', $client->getOptions()->getRelease());
+  }
+
+  /**
+   * Sentry does not listen for what Drupal already logs.
+   */
+  public function testLeavesTheHandlersDrupalAlreadyCoversAlone(): void {
+    putenv('SENTRY_DSN=' . self::DSN);
+
+    $client = SentryHubFactory::create()->getClient();
+
+    self::assertNotNull($client);
+    // Both of these end up in the log, and the logger sends them on, so
+    // listening for them too would open a second issue for one problem.
+    self::assertNull($client->getIntegration(ErrorListenerIntegration::class));
+    self::assertNull($client->getIntegration(ExceptionListenerIntegration::class));
+    // A request that runs out of memory never reaches the log at all.
+    self::assertNotNull($client->getIntegration(FatalErrorListenerIntegration::class));
+  }
+
+}

--- a/web/modules/custom/simplytest_sentry/tests/src/Unit/SentryLoggerTest.php
+++ b/web/modules/custom/simplytest_sentry/tests/src/Unit/SentryLoggerTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\simplytest_sentry\Unit;
+
+use Drupal\Core\Logger\LogMessageParser;
+use Drupal\Core\Logger\RfcLogLevel;
+use Drupal\simplytest_sentry\Logger\SentryLogger;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Sentry\ClientBuilder;
+use Sentry\Event;
+use Sentry\Severity;
+use Sentry\State\Hub;
+
+/**
+ * Covers what the logger hands to Sentry.
+ */
+#[CoversClass(SentryLogger::class)]
+#[Group('simplytest')]
+#[Group('simplytest_sentry')]
+final class SentryLoggerTest extends TestCase {
+
+  private RecordingTransport $transport;
+
+  private SentryLogger $sut;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->transport = new RecordingTransport();
+    // No integrations: they register global error handlers, and this is about
+    // what the logger puts in the payload.
+    $client = ClientBuilder::create([
+      'dsn' => 'https://examplePublicKey@o0.ingest.sentry.io/0',
+      'default_integrations' => FALSE,
+    ])
+      ->setTransport($this->transport)
+      ->getClient();
+    $this->sut = new SentryLogger(new Hub($client), new LogMessageParser());
+  }
+
+  /**
+   * A message is sent rendered, but grouped on the template behind it.
+   */
+  public function testSendsRenderedMessagesGroupedOnTheirTemplate(): void {
+    $this->sut->log(RfcLogLevel::ERROR, 'The latest build of base preview @name failed after @age.', [
+      'channel' => 'simplytest_tugboat',
+      '@name' => 'starshot',
+      '@age' => '2 hours',
+      'uid' => 0,
+    ]);
+
+    $event = $this->lastEvent();
+    self::assertEquals('The latest build of base preview starshot failed after 2 hours.', $event->getMessage());
+    self::assertEquals(Severity::error(), $event->getLevel());
+    // Grouped on the message before substitution, so reporting the same base
+    // again tomorrow lands in the same issue instead of opening a new one.
+    self::assertEquals(
+      ['simplytest_tugboat', 'The latest build of base preview @name failed after @age.'],
+      $event->getFingerprint(),
+    );
+    // What an alert rule can be written against.
+    self::assertEquals(['channel' => 'simplytest_tugboat'], $event->getTags());
+    // The values that made the message are kept, so the issue says which base.
+    self::assertEquals('starshot', $event->getExtra()['@name']);
+    self::assertEquals(0, $event->getExtra()['uid']);
+  }
+
+  /**
+   * An exception is sent as one, with a trace Sentry can read.
+   */
+  public function testSendsExceptionsWithTheirTrace(): void {
+    $this->sut->log(RfcLogLevel::ERROR, '%type: @message', [
+      'channel' => 'php',
+      '%type' => 'RuntimeException',
+      '@message' => 'Tugboat is unreachable',
+      'exception' => new \RuntimeException('Tugboat is unreachable'),
+    ]);
+
+    $event = $this->lastEvent();
+    $exceptions = $event->getExceptions();
+    self::assertCount(1, $exceptions);
+    self::assertEquals(\RuntimeException::class, $exceptions[0]->getType());
+    self::assertEquals('Tugboat is unreachable', $exceptions[0]->getValue());
+    // The rendered message is kept alongside it, since Drupal's is the one
+    // that says which operation failed.
+    self::assertEquals('RuntimeException: Tugboat is unreachable', $event->getExtra()['drupal_message']);
+    // The exception itself is never serialized into the payload: it holds
+    // whatever it was thrown with, which can be the whole HTTP client.
+    self::assertArrayNotHasKey('exception', $event->getExtra());
+  }
+
+  /**
+   * The worst levels are reported as fatal.
+   */
+  public function testReportsTheWorstLevelsAsFatal(): void {
+    $this->sut->log(RfcLogLevel::CRITICAL, 'The database is gone.', ['channel' => 'php']);
+    self::assertEquals(Severity::fatal(), $this->lastEvent()->getLevel());
+  }
+
+  /**
+   * Anything a person does not have to fix stays out of Sentry.
+   */
+  public function testIgnoresEverythingBelowError(): void {
+    $this->sut->log(RfcLogLevel::WARNING, 'Project @name has no releases.', ['channel' => 'simplytest_projects']);
+    $this->sut->log(RfcLogLevel::NOTICE, 'Session opened for @name.', ['channel' => 'user']);
+    $this->sut->log(RfcLogLevel::INFO, 'Building base preview @name.', ['channel' => 'simplytest_tugboat']);
+
+    self::assertEquals([], $this->transport->sent());
+  }
+
+  /**
+   * A message logged outside any channel still reports.
+   */
+  public function testFallsBackToThePhpChannel(): void {
+    $this->sut->log(RfcLogLevel::ERROR, 'Something went wrong.');
+
+    $event = $this->lastEvent();
+    self::assertEquals(['channel' => 'php'], $event->getTags());
+    self::assertEquals(['php', 'Something went wrong.'], $event->getFingerprint());
+  }
+
+  private function lastEvent(): Event {
+    $sent = $this->transport->sent();
+    self::assertNotEmpty($sent, 'The logger sent nothing to Sentry.');
+    return $sent[array_key_last($sent)];
+  }
+
+}

--- a/web/profiles/simplytest/simplytest.install
+++ b/web/profiles/simplytest/simplytest.install
@@ -44,3 +44,14 @@ function simplytest_fetch_drupal_core_versions() {
   $core_version_manager->updateData(9);
   $core_version_manager->updateData(10);
 }
+
+/**
+ * Installs the Sentry logger.
+ */
+function simplytest_update_11001(): void {
+  // Config import would install the module on its own, from the entry in
+  // core.extension.yml. Installing it here instead means the database matches
+  // config/sync by the time anything compares the two, which is what
+  // `drush deploy` and the config:status CI job do.
+  \Drupal::service('module_installer')->install(['simplytest_sentry']);
+}


### PR DESCRIPTION
## What

A custom `simplytest_sentry` module: one logger service, tagged `logger`, that forwards Drupal log messages at error level and above to Sentry. No `raven`.

## Why

Log entries are how the site says something is wrong, and nothing was reading them. `lagoon_logs` keeps everything, but keeping is not telling. This is what turns a base preview that stops building (#646) into something somebody hears about.

`raven` would do this, and about fifteen other things: tracing, JavaScript error handling, release health, cron monitoring, a report dialog, a configuration form for all of it. We would turn most of that off. What is left is small enough to own, and owning it means the fingerprinting below is a five-line decision rather than a feature request.

## How

Three files of substance.

`SentryHubFactory` builds the hub from the environment — `SENTRY_DSN`, then `SENTRY_ENVIRONMENT` falling back to `LAGOON_ENVIRONMENT`, and `SENTRY_RELEASE` falling back to `LAGOON_GIT_SHA`. No DSN in `config/sync`, and a hub with no client drops everything it is given, so an environment Lagoon did not give a DSN reports nothing without the logger having to know. The variables are set on `main` only, which keeps pull request environments out of the project.

`SentryLogger` sends `error` and worse. Everything a sandbox does wrong on the way in is a warning or a notice.

Two decisions worth reviewing:

- **Events are fingerprinted on the message before substitution.** Sentry groups on what it is given, and these messages carry the values that made them — a base preview name, an age, a project. `The latest build of base preview @name failed. Launches keep using the base built @age ago.` would open a new issue every single time it was reported. Grouping on the template gives one issue per thing that is wrong. The channel is a tag, so alert rules can be written against `simplytest_tugboat`.
- **Sentry's error and exception listeners are removed.** Drupal logs PHP errors and uncaught exceptions itself and the logger sends those on, so leaving them installed reports one problem twice. The fatal listener stays: a request that runs out of memory never reaches the logger, and that is the failure nobody finds out about otherwise.

The exception in a log context is sent as an exception, so Sentry builds a real trace, and only scalars go into the payload. Serializing the exception object drags in whatever it was thrown with — for an HTTP client error, the request, the response, and the handler stack.

A profile update hook installs the module. Config import would install it on its own, from the entry in `core.extension.yml`, but the `config:status` job compares the database against `config/sync` as soon as update hooks have run — so a module being added has to be installed by one. It is also the order `drush deploy` runs in.

## Testing notes

Nine unit tests: what the logger puts in the payload, driven through a real client with a recording transport rather than a mock, and what the factory builds from each combination of environment variables. PHPStan and Rector are green. The coverage gate could not run locally — no coverage driver in the container — so CI is the check on that.

Docs in `docs/sentry.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

